### PR TITLE
Optimize performance: throttle redraws, cache effects, flush settings…

### DIFF
--- a/src/hooks/use-p5.ts
+++ b/src/hooks/use-p5.ts
@@ -52,11 +52,25 @@ export function useP5<T>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef]);
 
-  // Trigger redraw on settings change (static mode only)
+  // Trigger redraw on settings change (static mode only).
+  // Throttle to one redraw per animation frame so rapid slider drags
+  // don't queue multiple expensive synchronous redraws.
+  const rafRef = useRef<number | null>(null);
+
   useEffect(() => {
     if (!options?.animated && instanceRef.current) {
-      instanceRef.current.redraw();
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        instanceRef.current?.redraw();
+      });
     }
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
   }, [settings, options?.animated]);
 
   return instanceRef;

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -27,24 +27,32 @@ export function useSettings<T extends Record<string, unknown>>(
   });
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef<T | null>(null);
 
   // Debounced write to localStorage
   const writeToStorage = useCallback(
     (value: T) => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      pendingRef.current = value;
       timerRef.current = setTimeout(() => {
         localStorage.setItem(storageKey, JSON.stringify(value));
+        pendingRef.current = null;
       }, 200);
     },
     [storageKey],
   );
 
-  // Cleanup timer on unmount
+  // Flush pending write on unmount so settings aren't lost
   useEffect(() => {
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        if (pendingRef.current !== null) {
+          localStorage.setItem(storageKey, JSON.stringify(pendingRef.current));
+        }
+      }
     };
-  }, []);
+  }, [storageKey]);
 
   const update = useCallback(
     (patch: Partial<T>) => {

--- a/src/hooks/use-shortcut-actions.ts
+++ b/src/hooks/use-shortcut-actions.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { shortcutActions } from '@/lib/shortcut-actions'
 
 interface Actions {
@@ -8,14 +8,17 @@ interface Actions {
 }
 
 export function useShortcutActions(actions: Actions) {
+  const ref = useRef(actions)
+  ref.current = actions
+
   useEffect(() => {
-    shortcutActions.randomize = actions.randomize ?? null
-    shortcutActions.reset = actions.reset ?? null
-    shortcutActions.download = actions.download ?? null
+    shortcutActions.randomize = () => ref.current.randomize?.()
+    shortcutActions.reset = () => ref.current.reset?.()
+    shortcutActions.download = () => ref.current.download?.()
     return () => {
       shortcutActions.randomize = null
       shortcutActions.reset = null
       shortcutActions.download = null
     }
-  })
+  }, [])
 }

--- a/src/tools/blocks/sketch.ts
+++ b/src/tools/blocks/sketch.ts
@@ -36,8 +36,21 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
   let cachedPolys: PolyBlock[] = []
   let cachedLayoutKey = ''
 
+  // Pre-effects canvas cache — avoids redrawing geometry when only effects change,
+  // and avoids re-running effects when only geometry changes with same effect params.
+  let preEffectsCanvas: OffscreenCanvas | null = null
+  let cachedDrawKey = ''
+  let cachedNoiseMap: Float32Array | null = null
+  let cachedNoiseMapW = 0
+  let cachedNoiseMapDims = ''
+
   function layoutKey(s: BlocksSettings): string {
     return `${s.seed}|${s.patternType}|${s.blockCount}|${s.complexity}|${s.asymmetry}|${s.gridDivisions}|${s.canvasSize}`
+  }
+
+  // Everything that affects the drawn geometry (before effects)
+  function drawKey(s: BlocksSettings): string {
+    return `${layoutKey(s)}|${s.colors.join(',')}|${s.colorDensity}|${s.lineWeight}|${s.lineColor}|${s.edgeWobble}|${s.rotation}`
   }
 
   p.setup = () => {
@@ -63,72 +76,90 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
       p.resizeCanvas(tw, th)
       p.colorMode(p.RGB, 255)
       cachedLayoutKey = '' // force recompute
+      cachedDrawKey = '' // force geometry redraw
     }
 
-    p.background('#f5f5f0')
+    const dk = drawKey(s)
+    const needsGeometryRedraw = dk !== cachedDrawKey
 
-    // Recompute layout if cache key changed
-    const lk = layoutKey(s)
-    if (lk !== cachedLayoutKey) {
-      computeLayout(s)
-      cachedLayoutKey = lk
-    }
+    if (needsGeometryRedraw) {
+      // Full geometry redraw
+      p.background('#f5f5f0')
 
-    // Assign colors deterministically
-    const colorRng = seededRandom(s.seed + 7)
-    const colorDensity = s.colorDensity / 100
-    const wobble = s.edgeWobble / 100
-
-    // Apply rotation
-    p.push()
-    p.translate(p.width / 2, p.height / 2)
-    p.rotate(p.radians(s.rotation))
-    p.translate(-p.width / 2, -p.height / 2)
-
-    if (s.patternType === 'diagonal') {
-      // Draw polygon blocks
-      const drawRng = seededRandom(s.seed + 13)
-      for (const poly of cachedPolys) {
-        const blockColor = pickColor(colorRng, colorDensity, s.colors)
-        drawPaintedPolygon(p, poly.points, blockColor, wobble, drawRng)
+      // Recompute layout if cache key changed
+      const lk = layoutKey(s)
+      if (lk !== cachedLayoutKey) {
+        computeLayout(s)
+        cachedLayoutKey = lk
       }
-      // Outlines
-      if (s.lineWeight > 0) {
-        const outlineRng = seededRandom(s.seed + 19)
-        p.stroke(s.lineColor)
-        p.strokeWeight(s.lineWeight)
-        p.noFill()
+
+      // Assign colors deterministically
+      const colorRng = seededRandom(s.seed + 7)
+      const colorDensity = s.colorDensity / 100
+      const wobble = s.edgeWobble / 100
+
+      // Apply rotation
+      p.push()
+      p.translate(p.width / 2, p.height / 2)
+      p.rotate(p.radians(s.rotation))
+      p.translate(-p.width / 2, -p.height / 2)
+
+      if (s.patternType === 'diagonal') {
+        const drawRng = seededRandom(s.seed + 13)
         for (const poly of cachedPolys) {
-          p.beginShape()
-          for (const pt of poly.points) {
-            p.vertex(
-              pt.x + (outlineRng() - 0.5) * wobble * 4,
-              pt.y + (outlineRng() - 0.5) * wobble * 4,
-            )
+          const blockColor = pickColor(colorRng, colorDensity, s.colors)
+          drawPaintedPolygon(p, poly.points, blockColor, wobble, drawRng)
+        }
+        if (s.lineWeight > 0) {
+          const outlineRng = seededRandom(s.seed + 19)
+          p.stroke(s.lineColor)
+          p.strokeWeight(s.lineWeight)
+          p.noFill()
+          for (const poly of cachedPolys) {
+            p.beginShape()
+            for (const pt of poly.points) {
+              p.vertex(
+                pt.x + (outlineRng() - 0.5) * wobble * 4,
+                pt.y + (outlineRng() - 0.5) * wobble * 4,
+              )
+            }
+            p.endShape(p.CLOSE)
           }
-          p.endShape(p.CLOSE)
         }
-      }
-    } else {
-      // Draw rect blocks
-      const drawRng = seededRandom(s.seed + 13)
-      for (const rect of cachedRects) {
-        const blockColor = pickColor(colorRng, colorDensity, s.colors)
-        drawPaintedBlock(p, rect, blockColor, wobble, drawRng)
-      }
-      // Outlines
-      if (s.lineWeight > 0) {
-        const outlineRng = seededRandom(s.seed + 19)
-        p.stroke(s.lineColor)
-        p.strokeWeight(s.lineWeight)
-        p.noFill()
+      } else {
+        const drawRng = seededRandom(s.seed + 13)
         for (const rect of cachedRects) {
-          drawWobblyRectOutline(p, rect, wobble, outlineRng)
+          const blockColor = pickColor(colorRng, colorDensity, s.colors)
+          drawPaintedBlock(p, rect, blockColor, wobble, drawRng)
+        }
+        if (s.lineWeight > 0) {
+          const outlineRng = seededRandom(s.seed + 19)
+          p.stroke(s.lineColor)
+          p.strokeWeight(s.lineWeight)
+          p.noFill()
+          for (const rect of cachedRects) {
+            drawWobblyRectOutline(p, rect, wobble, outlineRng)
+          }
         }
       }
-    }
 
-    p.pop()
+      p.pop()
+
+      // Snapshot pre-effects state to offscreen canvas
+      const c = ctx()
+      const d = p.pixelDensity()
+      const pw = p.width * d
+      const ph = p.height * d
+      if (!preEffectsCanvas || preEffectsCanvas.width !== pw || preEffectsCanvas.height !== ph) {
+        preEffectsCanvas = new OffscreenCanvas(pw, ph)
+      }
+      preEffectsCanvas.getContext('2d')!.drawImage(c.canvas, 0, 0)
+      cachedDrawKey = dk
+    } else {
+      // Geometry hasn't changed — restore from cache
+      const c = ctx()
+      c.drawImage(preEffectsCanvas!, 0, 0)
+    }
 
     // Post-processing effects
     if (s.texture > 0 || s.grain > 0 || s.halftone > 0) {
@@ -450,24 +481,34 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
       const textureVariation = textureStrength * 50
       const grainVariation = grainStrength * 35
 
-      // Pre-compute texture noise at half resolution — p.noise() is expensive per-pixel
+      // Noise map only depends on canvas dimensions (always seeded with 42).
+      // Cache it so dragging texture/grain sliders doesn't recompute Perlin noise.
       let noiseMap: Float32Array | null = null
       let nmW = 0
       if (textureStrength > 0) {
-        p.noiseSeed(42)
-        const step = 2
-        nmW = Math.ceil(w / (d * step))
-        const nmH = Math.ceil(h / (d * step))
-        noiseMap = new Float32Array(nmW * nmH)
-        for (let ny = 0; ny < nmH; ny++) {
-          const py = ny * step
-          for (let nx = 0; nx < nmW; nx++) {
-            const px = nx * step
-            const fine = p.noise(px * 0.5, py * 0.5) - 0.5
-            const med = p.noise(px * 0.08 + 100, py * 0.08 + 100) - 0.5
-            const coarse = p.noise(px * 0.02 + 200, py * 0.02 + 200) - 0.5
-            noiseMap[ny * nmW + nx] = (fine * 0.4 + med * 0.35 + coarse * 0.25) * 2
+        const dims = `${w}|${h}|${d}`
+        if (cachedNoiseMap && cachedNoiseMapDims === dims) {
+          noiseMap = cachedNoiseMap
+          nmW = cachedNoiseMapW
+        } else {
+          p.noiseSeed(42)
+          const step = 2
+          nmW = Math.ceil(w / (d * step))
+          const nmH = Math.ceil(h / (d * step))
+          noiseMap = new Float32Array(nmW * nmH)
+          for (let ny = 0; ny < nmH; ny++) {
+            const py = ny * step
+            for (let nx = 0; nx < nmW; nx++) {
+              const px = nx * step
+              const fine = p.noise(px * 0.5, py * 0.5) - 0.5
+              const med = p.noise(px * 0.08 + 100, py * 0.08 + 100) - 0.5
+              const coarse = p.noise(px * 0.02 + 200, py * 0.02 + 200) - 0.5
+              noiseMap[ny * nmW + nx] = (fine * 0.4 + med * 0.35 + coarse * 0.25) * 2
+            }
           }
+          cachedNoiseMap = noiseMap
+          cachedNoiseMapW = nmW
+          cachedNoiseMapDims = dims
         }
       }
 


### PR DESCRIPTION
… on unmount

Throttle p5 redraws to one per animation frame to prevent slider drags from queueing expensive synchronous redraws. Cache pre-effects canvas and noise map in blocks tool so texture/grain sliders don't redraw geometry or recompute Perlin noise. Flush pending localStorage writes on unmount so rapid setting changes aren't lost. Fix useShortcutActions to use ref for latest actions.