### PR TITLE
Allow background color customization in Blocks tool

### DIFF
--- a/src/tools/blocks/index.tsx
+++ b/src/tools/blocks/index.tsx
@@ -17,6 +17,7 @@ import type { BlocksSettings } from './types'
 
 const DEFAULTS: BlocksSettings = {
   seed: 4242,
+  bgColor: '#f5f5f0',
   patternType: 'mondrian',
   blockCount: 6,
   complexity: 4,
@@ -66,8 +67,10 @@ export default function Blocks() {
     const paletteNames = Object.keys(PALETTES)
     const palName = paletteNames[Math.floor(Math.random() * paletteNames.length)]
 
+    const bgColors = ['#f5f5f0', '#1a1a1a', '#0a0a0a', '#000000', '#2c2c2c', '#f0e6d3', '#e8e0d0']
     update({
       seed: Math.floor(Math.random() * 99999),
+      bgColor: bgColors[Math.floor(Math.random() * bgColors.length)],
       patternType: patternTypes[Math.floor(Math.random() * patternTypes.length)],
       blockCount: Math.floor(Math.random() * 15) + 3,
       complexity: Math.floor(Math.random() * 7) + 1,
@@ -186,6 +189,11 @@ export default function Blocks() {
         </Section>
 
         <Section title="Color">
+          <ColorControl
+            label="Background"
+            value={settings.bgColor}
+            onChange={(v) => update({ bgColor: v })}
+          />
           <SelectControl
             label="Palette"
             value={settings.palette}

--- a/src/tools/blocks/sketch.ts
+++ b/src/tools/blocks/sketch.ts
@@ -50,7 +50,7 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
 
   // Everything that affects the drawn geometry (before effects)
   function drawKey(s: BlocksSettings): string {
-    return `${layoutKey(s)}|${s.colors.join(',')}|${s.colorDensity}|${s.lineWeight}|${s.lineColor}|${s.edgeWobble}|${s.rotation}`
+    return `${layoutKey(s)}|${s.bgColor}|${s.colors.join(',')}|${s.colorDensity}|${s.lineWeight}|${s.lineColor}|${s.edgeWobble}|${s.rotation}`
   }
 
   p.setup = () => {
@@ -84,7 +84,7 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
 
     if (needsGeometryRedraw) {
       // Full geometry redraw
-      p.background('#f5f5f0')
+      p.background(s.bgColor)
 
       // Recompute layout if cache key changed
       const lk = layoutKey(s)

--- a/src/tools/blocks/types.ts
+++ b/src/tools/blocks/types.ts
@@ -1,5 +1,6 @@
 export type BlocksSettings = {
   seed: number
+  bgColor: string
   patternType: 'mondrian' | 'grid' | 'horizontal' | 'diagonal'
   blockCount: number
   complexity: number


### PR DESCRIPTION
Add configurable `bgColor` setting to the Blocks tool, matching the pattern of other tools (topo, organic, lines). Users can now change the background color instead of being stuck with the hardcoded `#f5f5f0`. The Randomize function also now includes background colors from a curated palette. Fixes #3.