### PR TITLE
Add shareable URLs for tool settings

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,9 +1,33 @@
 import React, { useRef, useCallback, useEffect, useState } from 'react'
 import { useMobile } from '@/hooks/use-mobile'
+import { shortcutActions } from '@/lib/shortcut-actions'
+import { Kbd } from '@/components/ui/kbd'
 
 interface SidebarProps {
   children: React.ReactNode
   footer?: React.ReactNode
+}
+
+function CopyLinkButton() {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    function onCopied() {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    }
+    window.addEventListener('studio:link-copied', onCopied)
+    return () => window.removeEventListener('studio:link-copied', onCopied)
+  }, [])
+
+  return (
+    <button
+      onClick={() => shortcutActions.copyLink?.()}
+      className="flex h-7 w-full items-center justify-center gap-1.5 rounded-md text-xs text-text-muted transition-colors duration-150 hover:text-text-primary"
+    >
+      {copied ? 'Copied!' : <>Copy Link <Kbd>C</Kbd></>}
+    </button>
+  )
 }
 
 function SidebarInner({ children, footer }: SidebarProps) {
@@ -13,10 +37,13 @@ function SidebarInner({ children, footer }: SidebarProps) {
         {children}
       </div>
       {footer && (
-        <div className="shrink-0 border-t border-border-control p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <div className="shrink-0 border-t border-border-control p-4 pb-0">
           {footer}
         </div>
       )}
+      <div className="shrink-0 px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <CopyLinkButton />
+      </div>
     </>
   )
 }

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -33,6 +33,11 @@ export function useKeyboardShortcuts() {
         return
       }
 
+      if (e.key === 'c' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        shortcutActions.copyLink?.()
+        return
+      }
+
       if (e.key === 'r' && !e.metaKey && !e.ctrlKey && !e.altKey) {
         shortcutActions.randomize?.()
         return

--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -1,4 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { shortcutActions } from "@/lib/shortcut-actions";
+import {
+  settingsFromBase64Url,
+  settingsToBase64Url,
+  settingsToDiff,
+} from "@/lib/url-settings";
 
 /**
  * Persist tool settings to localStorage with debounced writes.
@@ -12,8 +18,22 @@ export function useSettings<T extends Record<string, unknown>>(
   defaults: T,
 ): [T, (patch: Partial<T>) => void, () => void] {
   const storageKey = `studio:${key}`;
+  const defaultsRef = useRef(defaults);
 
   const [settings, setSettings] = useState<T>(() => {
+    // Priority: URL params > localStorage > defaults
+    const urlParams = new URLSearchParams(window.location.search);
+    const encoded = urlParams.get("s");
+    if (encoded) {
+      const decoded = settingsFromBase64Url(encoded);
+      if (decoded) {
+        const merged = { ...defaults, ...(decoded as Partial<T>) };
+        localStorage.setItem(storageKey, JSON.stringify(merged));
+        window.history.replaceState({}, "", window.location.pathname);
+        return merged;
+      }
+    }
+
     try {
       const raw = localStorage.getItem(storageKey);
       if (raw) {
@@ -53,6 +73,37 @@ export function useSettings<T extends Record<string, unknown>>(
       }
     };
   }, [storageKey]);
+
+  // Register copyLink shortcut action
+  useEffect(() => {
+    shortcutActions.copyLink = () => {
+      // Flush pending debounced write
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        if (pendingRef.current !== null) {
+          localStorage.setItem(storageKey, JSON.stringify(pendingRef.current));
+          pendingRef.current = null;
+        }
+      }
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return;
+      try {
+        const current = JSON.parse(raw) as Record<string, unknown>;
+        const diff = settingsToDiff(current, defaultsRef.current);
+        const hasChanges = Object.keys(diff).length > 0;
+        const url = hasChanges
+          ? `${window.location.origin}/${key}?s=${settingsToBase64Url(diff)}`
+          : `${window.location.origin}/${key}`;
+        navigator.clipboard.writeText(url);
+        window.dispatchEvent(new CustomEvent("studio:link-copied"));
+      } catch {
+        // clipboard or encoding failure — silently ignore
+      }
+    };
+    return () => {
+      shortcutActions.copyLink = null;
+    };
+  }, [key, storageKey]);
 
   const update = useCallback(
     (patch: Partial<T>) => {

--- a/src/lib/shortcut-actions.ts
+++ b/src/lib/shortcut-actions.ts
@@ -2,4 +2,5 @@ export const shortcutActions = {
   randomize: null as (() => void) | null,
   reset: null as (() => void) | null,
   download: null as (() => void) | null,
+  copyLink: null as (() => void) | null,
 }

--- a/src/lib/url-settings.ts
+++ b/src/lib/url-settings.ts
@@ -1,0 +1,44 @@
+/**
+ * URL-based settings encoding for shareable links.
+ * Encodes only the diff from defaults to keep URLs short.
+ */
+
+/** Return only the keys in `settings` whose values differ from `defaults`. */
+export function settingsToDiff(
+  settings: Record<string, unknown>,
+  defaults: Record<string, unknown>,
+): Record<string, unknown> {
+  const diff: Record<string, unknown> = {}
+  for (const key of Object.keys(settings)) {
+    const a = settings[key]
+    const b = defaults[key]
+    // Deep-compare arrays/objects via JSON, primitive compare via ===
+    if (typeof a === "object" || typeof b === "object") {
+      if (JSON.stringify(a) !== JSON.stringify(b)) diff[key] = a
+    } else if (a !== b) {
+      diff[key] = a
+    }
+  }
+  return diff
+}
+
+/** Encode a settings object to a URL-safe base64 string. */
+export function settingsToBase64Url(settings: Record<string, unknown>): string {
+  return btoa(JSON.stringify(settings))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+/** Decode a base64url string back to a settings object. Returns null on failure. */
+export function settingsFromBase64Url(
+  encoded: string,
+): Record<string, unknown> | null {
+  try {
+    let s = encoded.replace(/-/g, "+").replace(/_/g, "/")
+    while (s.length % 4) s += "="
+    return JSON.parse(atob(s))
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
Encode tool settings into shareable URLs via ?s= query parameter. Settings are encoded as a minimal diff from defaults using base64url, producing short URLs for small tweaks (e.g., changing just the seed → /blocks?s=eyJzZWVkIjo5OTk5fQ).

On load, settings are restored from the URL (priority: URL > localStorage > defaults) and immediately saved to localStorage so users can keep tweaking. A "Copy Link" button in the sidebar footer (plus c keyboard shortcut) copies the current URL. The UI shows "Copied!" feedback for 1.5 seconds. No changes to any tool components.