### PR TITLE
feature: created export function in /lib, used it in all random generators

### DIFF
--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -31,6 +31,22 @@ export function exportSVG(svgString: string, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+/** Wrap a canvas PNG snapshot in an SVG container and download it. */
+export function exportSVGFromCanvas(
+  canvas: HTMLCanvasElement,
+  filename: string,
+): void {
+  const width = canvas.width;
+  const height = canvas.height;
+  const dataUrl = canvas.toDataURL("image/png");
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" ` +
+    `width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">` +
+    `<image href="${dataUrl}" width="${width}" height="${height}"/>` +
+    `</svg>`;
+  exportSVG(svg, filename);
+}
+
 interface RecorderOptions {
   width: number;
   height: number;

--- a/src/tools/ascii/index.tsx
+++ b/src/tools/ascii/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from "react"
 import { useSettings } from "@/hooks/use-settings"
 import { useP5 } from "@/hooks/use-p5"
-import { exportPNG, generateFilename } from "@/lib/export"
+import { exportPNG, exportSVGFromCanvas, generateFilename } from "@/lib/export"
 import { CanvasArea } from "@/components/canvas-area"
 import { Sidebar } from "@/components/sidebar"
 import { Section } from "@/components/controls/section"
@@ -250,6 +250,13 @@ export default function Ascii() {
     exportPNG(canvas, generateFilename("ascii", "png"))
   }, [p5Ref])
 
+  const handleExportSVG = useCallback(() => {
+    const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })
+      ?.canvas
+    if (!canvas) return
+    exportSVGFromCanvas(canvas, generateFilename("ascii", "svg"))
+  }, [p5Ref])
+
   function randomize() {
     const r = Math.random
     const ri = (min: number, max: number) =>
@@ -389,7 +396,7 @@ export default function Ascii() {
     update(patch)
   }
 
-  useShortcutActions({ randomize, reset, download: handleExportPNG })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   const enabledSets = SET_NAMES.filter((n) => settings.setConfig[n].enabled)
 
@@ -407,9 +414,16 @@ export default function Ascii() {
             <Button
               variant="primary"
               className="w-full"
+              onClick={handleExportSVG}
+            >
+              Export SVG <Kbd>⌘S</Kbd>
+            </Button>
+            <Button
+              variant="secondary"
+              className="w-full"
               onClick={handleExportPNG}
             >
-              Download <Kbd>⌘S</Kbd>
+              Export PNG
             </Button>
           </ButtonRow>
         }

--- a/src/tools/blocks/index.tsx
+++ b/src/tools/blocks/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -43,7 +43,7 @@ export default function Blocks() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [settings, update, reset] = useSettings<BlocksSettings>('blocks', DEFAULTS)
   const p5Ref = useP5(containerRef, createBlocksSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -88,10 +88,17 @@ export default function Blocks() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('blocks', 'png'))
+    }
+  }
+
+  function handleExportSVG() {
+    const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
+    if (canvas) {
+      exportSVGFromCanvas(canvas, generateFilename('blocks', 'svg'))
     }
   }
 
@@ -101,7 +108,8 @@ export default function Blocks() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Blocks</h2>

--- a/src/tools/gradients/index.tsx
+++ b/src/tools/gradients/index.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename, createRecorder } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename, createRecorder } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -83,7 +83,7 @@ export default function Gradients() {
   )
 
   useP5(containerRef, sketchFn, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function handleColorStopsChange(colorStops: ColorStop[]) {
     update({ colorStops })
@@ -132,10 +132,17 @@ export default function Gradients() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = containerRef.current?.querySelector('canvas')
     if (canvas) {
       exportPNG(canvas, generateFilename('gradients', 'png'))
+    }
+  }
+
+  function handleExportSVG() {
+    const canvas = containerRef.current?.querySelector('canvas')
+    if (canvas) {
+      exportSVGFromCanvas(canvas, generateFilename('gradients', 'svg'))
     }
   }
 
@@ -176,7 +183,8 @@ export default function Gradients() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
           <Button variant="secondary" onClick={toggleRecording}>
             {isRecording ? 'Stop Recording' : 'Record MP4'}
           </Button>

--- a/src/tools/lines/index.tsx
+++ b/src/tools/lines/index.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename, createRecorder } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename, createRecorder } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -99,7 +99,7 @@ export default function Lines() {
   )
 
   useP5(containerRef, sketchFn, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function randomize() {
     const shapes: LinesSettings['shape'][] = ['horizontal', 'vertical', 'circles', 'dots', 'spiral', 'radial', 'lissajous']
@@ -210,9 +210,14 @@ export default function Lines() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = containerRef.current?.querySelector('canvas')
     if (canvas) exportPNG(canvas, generateFilename('lines', 'png'))
+  }
+
+  function handleExportSVG() {
+    const canvas = containerRef.current?.querySelector('canvas')
+    if (canvas) exportSVGFromCanvas(canvas, generateFilename('lines', 'svg'))
   }
 
   async function toggleRecording() {
@@ -247,7 +252,8 @@ export default function Lines() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
           <Button variant="secondary" onClick={toggleRecording}>
             {isRecording ? 'Stop Recording' : 'Record MP4'}
           </Button>

--- a/src/tools/organic/index.tsx
+++ b/src/tools/organic/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -62,7 +62,7 @@ export default function Organic() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [settings, update, reset] = useSettings<OrganicSettings>('organic', DEFAULTS)
   const p5Ref = useP5(containerRef, createOrganicSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -142,10 +142,17 @@ export default function Organic() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('organic', 'png'))
+    }
+  }
+
+  function handleExportSVG() {
+    const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
+    if (canvas) {
+      exportSVGFromCanvas(canvas, generateFilename('organic', 'svg'))
     }
   }
 
@@ -155,7 +162,8 @@ export default function Organic() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Organic</h2>

--- a/src/tools/plotter/index.tsx
+++ b/src/tools/plotter/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -79,7 +79,7 @@ export default function Plotter() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [settings, update, reset] = useSettings<PlotterSettings>('plotter', DEFAULTS)
   const p5Ref = useP5(containerRef, createPlotterSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -194,9 +194,14 @@ export default function Plotter() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) exportPNG(canvas, generateFilename('plotter', 'png'))
+  }
+
+  function handleExportSVG() {
+    const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
+    if (canvas) exportSVGFromCanvas(canvas, generateFilename('plotter', 'svg'))
   }
 
   return (
@@ -205,7 +210,8 @@ export default function Plotter() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Plotter</h2>

--- a/src/tools/topo/index.tsx
+++ b/src/tools/topo/index.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVGFromCanvas, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -57,7 +57,7 @@ export default function Topo() {
   const containerRef = useRef<HTMLDivElement>(null)
   const [settings, update, reset] = useSettings<TopoSettings>('topo', DEFAULTS)
   const p5Ref = useP5(containerRef, createTopoSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  useShortcutActions({ randomize, reset, download: handleExportSVG })
 
   function randomize() {
     const paletteNames = ['mono', 'topo', 'ocean', 'earth', 'sunset', 'forest', 'heat']
@@ -108,10 +108,17 @@ export default function Topo() {
     })
   }
 
-  function download() {
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('topo', 'png'))
+    }
+  }
+
+  function handleExportSVG() {
+    const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
+    if (canvas) {
+      exportSVGFromCanvas(canvas, generateFilename('topo', 'svg'))
     }
   }
 
@@ -121,7 +128,8 @@ export default function Topo() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+          <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Topo</h2>


### PR DESCRIPTION
Issue : 
- Not able to export as SVG in all generators.

Solution : 
- Created a function in /lib 'exportSVGFromCanvas' that takes the current pixels from a canvas, converts those pixels into a PNG Data URL, then wraps that PNG Inside an SVG <image> tag, then downloads it as a .svg file. 