### PR TITLE
Add SVG export to topo, blocks, organic, plotter

### DIFF
--- a/src/tools/blocks/index.tsx
+++ b/src/tools/blocks/index.tsx
@@ -1,7 +1,9 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import type { RefObject } from 'react'
+import type p5 from 'p5'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVG, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -13,7 +15,8 @@ import { Button } from '@/components/ui/button'
 import { useShortcutActions } from '@/hooks/use-shortcut-actions'
 import { Kbd } from '@/components/ui/kbd'
 import { createBlocksSketch, PALETTES } from './sketch'
-import type { BlocksSettings } from './types'
+import { generateBlocksSvg } from './svg'
+import type { BlocksSettings, BlocksGeometry } from './types'
 
 const DEFAULTS: BlocksSettings = {
   seed: 4242,
@@ -41,9 +44,15 @@ const DEFAULTS: BlocksSettings = {
 
 export default function Blocks() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const geometryRef = useRef<BlocksGeometry | null>(null)
   const [settings, update, reset] = useSettings<BlocksSettings>('blocks', DEFAULTS)
-  const p5Ref = useP5(containerRef, createBlocksSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  const sketchFn = useCallback(
+    (p: p5, settingsRef: RefObject<BlocksSettings>) => createBlocksSketch(p, settingsRef, geometryRef),
+    [],
+  )
+  const p5Ref = useP5(containerRef, sketchFn, settings)
+  const hasRasterEffects = settings.texture > 0 || settings.grain > 0 || settings.halftone > 0
+  useShortcutActions({ randomize, reset, download: hasRasterEffects ? handleExportPNG : handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -88,7 +97,14 @@ export default function Blocks() {
     })
   }
 
-  function download() {
+  function handleExportSVG() {
+    const geo = geometryRef.current
+    if (!geo) return
+    const svg = generateBlocksSvg(geo, settings)
+    if (svg) exportSVG(svg, generateFilename('blocks', 'svg'))
+  }
+
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('blocks', 'png'))
@@ -101,7 +117,17 @@ export default function Blocks() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          {hasRasterEffects ? (
+            <>
+              <Button variant="primary" onClick={handleExportPNG}>Export PNG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportSVG}>Export SVG</Button>
+            </>
+          ) : (
+            <>
+              <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
+            </>
+          )}
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Blocks</h2>

--- a/src/tools/blocks/sketch.ts
+++ b/src/tools/blocks/sketch.ts
@@ -1,6 +1,6 @@
 import type p5 from 'p5'
 import type { RefObject } from 'react'
-import type { BlocksSettings } from './types'
+import type { BlocksSettings, RectBlock, PolyBlock, BlocksGeometry } from './types'
 import { seededRandom } from '@/lib/math'
 
 export const PALETTES: Record<string, string[]> = {
@@ -17,18 +17,14 @@ export const CANVAS_SIZES: Record<string, [number, number]> = {
   portrait: [768, 1024],
 }
 
-interface RectBlock {
-  x: number
-  y: number
-  w: number
-  h: number
+export function pickColor(rng: () => number, colorDensity: number, colors: string[]): string {
+  if (rng() < colorDensity) {
+    return colors[Math.floor(rng() * 3) % colors.length]
+  }
+  return colors[Math.floor(rng() * 2 + 3) % colors.length]
 }
 
-interface PolyBlock {
-  points: { x: number; y: number }[]
-}
-
-export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>) {
+export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>, geometryRef?: RefObject<BlocksGeometry | null>) {
   const ctx = () => p.drawingContext as CanvasRenderingContext2D
 
   // Cached geometry
@@ -91,6 +87,11 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
       if (lk !== cachedLayoutKey) {
         computeLayout(s)
         cachedLayoutKey = lk
+      }
+
+      // Expose geometry for SVG export
+      if (geometryRef) {
+        geometryRef.current = { rects: cachedRects, polys: cachedPolys, width: p.width, height: p.height }
       }
 
       // Assign colors deterministically
@@ -165,13 +166,6 @@ export function createBlocksSketch(p: p5, settingsRef: RefObject<BlocksSettings>
     if (s.texture > 0 || s.grain > 0 || s.halftone > 0) {
       applyEffects(s)
     }
-  }
-
-  function pickColor(rng: () => number, colorDensity: number, colors: string[]): string {
-    if (rng() < colorDensity) {
-      return colors[Math.floor(rng() * 3) % colors.length]
-    }
-    return colors[Math.floor(rng() * 2 + 3) % colors.length]
   }
 
   function computeLayout(s: BlocksSettings) {

--- a/src/tools/blocks/svg.ts
+++ b/src/tools/blocks/svg.ts
@@ -1,0 +1,199 @@
+import type { BlocksSettings, BlocksGeometry, RectBlock } from './types'
+import { pickColor } from './sketch'
+import { seededRandom } from '@/lib/math'
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function pointsToPolygon(points: { x: number; y: number }[]): string {
+  return points.map((p) => `${round2(p.x)},${round2(p.y)}`).join(' ')
+}
+
+/** Generate wobbled vertices for a rect block — mirrors drawPaintedBlock in sketch.ts exactly. */
+function rectFillVertices(rect: RectBlock, wobble: number, rng: () => number): { x: number; y: number }[] {
+  if (wobble <= 0) {
+    return [
+      { x: rect.x, y: rect.y },
+      { x: rect.x + rect.w, y: rect.y },
+      { x: rect.x + rect.w, y: rect.y + rect.h },
+      { x: rect.x, y: rect.y + rect.h },
+    ]
+  }
+
+  const maxWobble = wobble * 4
+  const segments = 15
+  const pts: { x: number; y: number }[] = []
+
+  // Top edge
+  for (let i = 0; i <= segments; i++) {
+    pts.push({
+      x: rect.x + (rect.w * i) / segments,
+      y: rect.y + (rng() - 0.5) * maxWobble * 2,
+    })
+  }
+  // Right edge
+  for (let i = 1; i <= segments; i++) {
+    pts.push({
+      x: rect.x + rect.w + (rng() - 0.5) * maxWobble * 2,
+      y: rect.y + (rect.h * i) / segments,
+    })
+  }
+  // Bottom edge
+  for (let i = 1; i <= segments; i++) {
+    pts.push({
+      x: rect.x + rect.w - (rect.w * i) / segments,
+      y: rect.y + rect.h + (rng() - 0.5) * maxWobble * 2,
+    })
+  }
+  // Left edge
+  for (let i = 1; i < segments; i++) {
+    pts.push({
+      x: rect.x + (rng() - 0.5) * maxWobble * 2,
+      y: rect.y + rect.h - (rect.h * i) / segments,
+    })
+  }
+
+  return pts
+}
+
+/** Generate wobbled vertices for a polygon — mirrors drawPaintedPolygon in sketch.ts exactly. */
+function polyFillVertices(
+  originalPoints: { x: number; y: number }[],
+  wobble: number,
+  rng: () => number,
+): { x: number; y: number }[] {
+  if (wobble <= 0) {
+    return [...originalPoints]
+  }
+
+  const maxWobble = wobble * 4
+  const segments = 10
+  const pts: { x: number; y: number }[] = []
+
+  for (let i = 0; i < originalPoints.length; i++) {
+    const p1 = originalPoints[i]
+    const p2 = originalPoints[(i + 1) % originalPoints.length]
+    for (let j = 0; j < segments; j++) {
+      const t = j / segments
+      pts.push({
+        x: p1.x + (p2.x - p1.x) * t + (rng() - 0.5) * maxWobble * 2,
+        y: p1.y + (p2.y - p1.y) * t + (rng() - 0.5) * maxWobble * 2,
+      })
+    }
+  }
+
+  return pts
+}
+
+/** Generate wobbled outline vertices for a rect — mirrors drawWobblyRectOutline in sketch.ts exactly. */
+function rectOutlineVertices(rect: RectBlock, wobble: number, rng: () => number): { x: number; y: number }[] {
+  const pts: { x: number; y: number }[] = []
+
+  for (let i = 0; i <= 10; i++) {
+    pts.push({
+      x: rect.x + (rect.w * i) / 10 + (rng() - 0.5) * wobble * 4,
+      y: rect.y + (rng() - 0.5) * wobble * 4,
+    })
+  }
+  for (let i = 0; i <= 10; i++) {
+    pts.push({
+      x: rect.x + rect.w + (rng() - 0.5) * wobble * 4,
+      y: rect.y + (rect.h * i) / 10 + (rng() - 0.5) * wobble * 4,
+    })
+  }
+  for (let i = 0; i <= 10; i++) {
+    pts.push({
+      x: rect.x + rect.w - (rect.w * i) / 10 + (rng() - 0.5) * wobble * 4,
+      y: rect.y + rect.h + (rng() - 0.5) * wobble * 4,
+    })
+  }
+  for (let i = 0; i <= 10; i++) {
+    pts.push({
+      x: rect.x + (rng() - 0.5) * wobble * 4,
+      y: rect.y + rect.h - (rect.h * i) / 10 + (rng() - 0.5) * wobble * 4,
+    })
+  }
+
+  return pts
+}
+
+/** Generate wobbled outline vertices for a polygon — mirrors the outline loop in sketch.ts exactly. */
+function polyOutlineVertices(
+  originalPoints: { x: number; y: number }[],
+  wobble: number,
+  rng: () => number,
+): { x: number; y: number }[] {
+  return originalPoints.map((pt) => ({
+    x: pt.x + (rng() - 0.5) * wobble * 4,
+    y: pt.y + (rng() - 0.5) * wobble * 4,
+  }))
+}
+
+export function generateBlocksSvg(
+  geometry: BlocksGeometry,
+  settings: BlocksSettings,
+): string {
+  const { width, height } = geometry
+  const wobble = settings.edgeWobble / 100
+  const colorDensity = settings.colorDensity / 100
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n`
+  svg += `  <rect width="100%" height="100%" fill="${settings.bgColor}"/>\n`
+
+  // Rotation wrapper
+  const hasRotation = settings.rotation !== 0
+  const cx = width / 2
+  const cy = height / 2
+
+  if (hasRotation) {
+    svg += `  <g transform="translate(${cx},${cy}) rotate(${settings.rotation}) translate(${-cx},${-cy})">\n`
+  }
+
+  const indent = hasRotation ? '    ' : '  '
+
+  if (settings.patternType === 'diagonal') {
+    // Diagonal: use polys
+    const colorRng = seededRandom(settings.seed + 7)
+    const drawRng = seededRandom(settings.seed + 13)
+
+    for (const poly of geometry.polys) {
+      const color = pickColor(colorRng, colorDensity, settings.colors)
+      const pts = polyFillVertices(poly.points, wobble, drawRng)
+      svg += `${indent}<polygon points="${pointsToPolygon(pts)}" fill="${color}" stroke="none"/>\n`
+    }
+
+    if (settings.lineWeight > 0) {
+      const outlineRng = seededRandom(settings.seed + 19)
+      for (const poly of geometry.polys) {
+        const pts = polyOutlineVertices(poly.points, wobble, outlineRng)
+        svg += `${indent}<polygon points="${pointsToPolygon(pts)}" fill="none" stroke="${settings.lineColor}" stroke-width="${settings.lineWeight}" stroke-linecap="round" stroke-linejoin="round"/>\n`
+      }
+    }
+  } else {
+    // Non-diagonal: use rects
+    const colorRng = seededRandom(settings.seed + 7)
+    const drawRng = seededRandom(settings.seed + 13)
+
+    for (const rect of geometry.rects) {
+      const color = pickColor(colorRng, colorDensity, settings.colors)
+      const pts = rectFillVertices(rect, wobble, drawRng)
+      svg += `${indent}<polygon points="${pointsToPolygon(pts)}" fill="${color}" stroke="none"/>\n`
+    }
+
+    if (settings.lineWeight > 0) {
+      const outlineRng = seededRandom(settings.seed + 19)
+      for (const rect of geometry.rects) {
+        const pts = rectOutlineVertices(rect, wobble, outlineRng)
+        svg += `${indent}<polygon points="${pointsToPolygon(pts)}" fill="none" stroke="${settings.lineColor}" stroke-width="${settings.lineWeight}" stroke-linecap="round" stroke-linejoin="round"/>\n`
+      }
+    }
+  }
+
+  if (hasRotation) {
+    svg += `  </g>\n`
+  }
+
+  svg += `</svg>`
+  return svg
+}

--- a/src/tools/blocks/types.ts
+++ b/src/tools/blocks/types.ts
@@ -1,3 +1,7 @@
+export type RectBlock = { x: number; y: number; w: number; h: number }
+export type PolyBlock = { points: { x: number; y: number }[] }
+export type BlocksGeometry = { rects: RectBlock[]; polys: PolyBlock[]; width: number; height: number }
+
 export type BlocksSettings = {
   seed: number
   bgColor: string

--- a/src/tools/organic/index.tsx
+++ b/src/tools/organic/index.tsx
@@ -1,7 +1,9 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import type { RefObject } from 'react'
+import type p5 from 'p5'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVG, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -14,7 +16,8 @@ import { GradientEditor } from '@/components/controls/gradient-editor'
 import { useShortcutActions } from '@/hooks/use-shortcut-actions'
 import { Kbd } from '@/components/ui/kbd'
 import { createOrganicSketch } from './sketch'
-import type { OrganicSettings } from './types'
+import { generateOrganicSvg } from './svg'
+import type { OrganicSettings, OrganicGeometry } from './types'
 import type { ColorStop } from '@/types/tools'
 
 const PALETTES: Record<string, string[]> = {
@@ -60,9 +63,15 @@ const DEFAULTS: OrganicSettings = {
 
 export default function Organic() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const geometryRef = useRef<OrganicGeometry | null>(null)
   const [settings, update, reset] = useSettings<OrganicSettings>('organic', DEFAULTS)
-  const p5Ref = useP5(containerRef, createOrganicSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  const sketchFn = useCallback(
+    (p: p5, settingsRef: RefObject<OrganicSettings>) => createOrganicSketch(p, settingsRef, geometryRef),
+    [],
+  )
+  const p5Ref = useP5(containerRef, sketchFn, settings)
+  const hasRasterEffects = settings.grainAmount > 0 || settings.textureAmount > 0
+  useShortcutActions({ randomize, reset, download: hasRasterEffects ? handleExportPNG : handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -142,7 +151,14 @@ export default function Organic() {
     })
   }
 
-  function download() {
+  function handleExportSVG() {
+    const geo = geometryRef.current
+    if (!geo) return
+    const svg = generateOrganicSvg(geo, settings)
+    if (svg) exportSVG(svg, generateFilename('organic', 'svg'))
+  }
+
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('organic', 'png'))
@@ -155,7 +171,17 @@ export default function Organic() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          {hasRasterEffects ? (
+            <>
+              <Button variant="primary" onClick={handleExportPNG}>Export PNG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportSVG}>Export SVG</Button>
+            </>
+          ) : (
+            <>
+              <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
+            </>
+          )}
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Organic</h2>

--- a/src/tools/organic/sketch.ts
+++ b/src/tools/organic/sketch.ts
@@ -1,12 +1,7 @@
 import type p5 from 'p5'
 import type { RefObject } from 'react'
-import type { OrganicSettings } from './types'
+import type { OrganicSettings, PathPoint, OrganicGeometry } from './types'
 import { hexToRgb } from '@/lib/color'
-
-interface PathPoint {
-  x: number
-  y: number
-}
 
 interface ParsedStop {
   r: number
@@ -18,7 +13,7 @@ interface ParsedStop {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type P5Any = any
 
-export function createOrganicSketch(p: p5, settingsRef: RefObject<OrganicSettings>) {
+export function createOrganicSketch(p: p5, settingsRef: RefObject<OrganicSettings>, geometryRef?: RefObject<OrganicGeometry | null>) {
   const ctx = () => p.drawingContext as CanvasRenderingContext2D
 
   // Cached paths — recompute only when geometry-affecting settings change
@@ -118,8 +113,14 @@ export function createOrganicSketch(p: p5, settingsRef: RefObject<OrganicSetting
 
     // Render paths using direct canvas API
     const totalPaths = cachedPaths.length
+    const collectedPaths: PathPoint[][] = []
     for (let i = 0; i < totalPaths; i++) {
-      renderPath(cachedPaths[i], i, s, parsedStops, gradientConsts, c)
+      const processed = renderPath(cachedPaths[i], i, s, parsedStops, gradientConsts, c)
+      if (processed) collectedPaths.push(processed)
+    }
+
+    if (geometryRef) {
+      geometryRef.current = { paths: collectedPaths, width: p.width, height: p.height }
     }
 
     if (pad > 0) {
@@ -333,8 +334,8 @@ export function createOrganicSketch(p: p5, settingsRef: RefObject<OrganicSetting
     parsedStops: ParsedStop[],
     gc: GradientConsts,
     c: CanvasRenderingContext2D,
-  ) {
-    if (path.length < 2) return
+  ): PathPoint[] | null {
+    if (path.length < 2) return null
 
     const len = path.length
     const invLen = 1 / (len - 1)
@@ -439,6 +440,13 @@ export function createOrganicSketch(p: p5, settingsRef: RefObject<OrganicSetting
         c.stroke()
       }
     }
+
+    // Convert processed points back to PathPoint[]
+    const result: PathPoint[] = new Array(len)
+    for (let i = 0; i < len; i++) {
+      result[i] = { x: px[i], y: py[i] }
+    }
+    return result
   }
 
   // ============================================

--- a/src/tools/organic/svg.ts
+++ b/src/tools/organic/svg.ts
@@ -1,0 +1,161 @@
+import type { OrganicSettings, OrganicGeometry } from './types'
+import { hexToRgb } from '@/lib/color'
+
+interface ParsedStop {
+  r: number
+  g: number
+  b: number
+  position: number
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function parseAndSortStops(settings: OrganicSettings): ParsedStop[] {
+  const stops = settings.colorStops
+  if (stops.length === 0) return [{ r: 255, g: 255, b: 255, position: 0 }]
+  return [...stops]
+    .sort((a, b) => a.position - b.position)
+    .map(stop => {
+      const rgb = hexToRgb(stop.color) ?? { r: 255, g: 255, b: 255 }
+      return { r: rgb.r, g: rgb.g, b: rgb.b, position: stop.position }
+    })
+}
+
+function lerpParsedStops(t: number, sorted: ParsedStop[]): [number, number, number] {
+  if (sorted.length === 1) return [sorted[0].r, sorted[0].g, sorted[0].b]
+
+  const pos = t * 100
+  const first = sorted[0], last = sorted[sorted.length - 1]
+  if (pos <= first.position) return [first.r, first.g, first.b]
+  if (pos >= last.position) return [last.r, last.g, last.b]
+
+  let lower = first, upper = last
+  for (let i = 0; i < sorted.length - 1; i++) {
+    if (pos >= sorted[i].position && pos <= sorted[i + 1].position) {
+      lower = sorted[i]; upper = sorted[i + 1]; break
+    }
+  }
+
+  const range = upper.position - lower.position
+  if (range === 0) return [lower.r, lower.g, lower.b]
+
+  const factor = (pos - lower.position) / range
+  const s = factor * factor * (3 - 2 * factor) // Hermite smoothing
+  return [
+    (lower.r + (upper.r - lower.r) * s) | 0,
+    (lower.g + (upper.g - lower.g) * s) | 0,
+    (lower.b + (upper.b - lower.b) * s) | 0,
+  ]
+}
+
+export function generateOrganicSvg(
+  geometry: OrganicGeometry,
+  settings: OrganicSettings,
+): string {
+  const { paths, width, height } = geometry
+  const parsedStops = parseAndSortStops(settings)
+
+  const halfW = width / 2
+  const halfH = height / 2
+  const radialMaxDist = Math.sqrt(halfW * halfW + halfH * halfH)
+  const PI = Math.PI
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n`
+  svg += `  <rect width="100%" height="100%" fill="${settings.bgColor}"/>\n`
+
+  const pad = settings.padding
+  const hasClip = pad > 0
+
+  if (hasClip) {
+    svg += `  <defs>\n`
+    svg += `    <clipPath id="padding">\n`
+    svg += `      <rect x="${pad}" y="${pad}" width="${width - pad * 2}" height="${height - pad * 2}"/>\n`
+    svg += `    </clipPath>\n`
+    svg += `  </defs>\n`
+  }
+
+  const groupAttrs = hasClip ? ` clip-path="url(#padding)"` : ''
+  svg += `  <g stroke-linecap="round" stroke-linejoin="round"${groupAttrs}>\n`
+
+  const subdivisions = 4
+  const invSub = 1 / subdivisions
+  const hasTaper = settings.taper > 0
+  const taperAmount = settings.taper / 100
+  const baseWeight = settings.lineWeight
+  const gradType = settings.gradientType
+
+  for (const path of paths) {
+    if (path.length < 2) continue
+
+    const len = path.length
+    const invLen = 1 / (len - 1)
+
+    for (let i = 0; i < len - 1; i++) {
+      const t1 = i * invLen
+      const t2 = (i + 1) * invLen
+      const x1 = path[i].x
+      const y1 = path[i].y
+      const x2 = path[i + 1].x
+      const y2 = path[i + 1].y
+      const dx = x2 - x1
+      const dy = y2 - y1
+
+      for (let sub = 0; sub < subdivisions; sub++) {
+        const st1 = sub * invSub
+        const st2 = (sub + 1) * invSub
+
+        const sx1 = x1 + dx * st1
+        const sy1 = y1 + dy * st1
+        const sx2 = x1 + dx * st2
+        const sy2 = y1 + dy * st2
+
+        const midT = t1 + (t2 - t1) * ((st1 + st2) * 0.5)
+
+        let gradientT: number
+        if (gradType === 'pathAlong') {
+          gradientT = midT
+        } else {
+          const mx = (sx1 + sx2) * 0.5
+          const my = (sy1 + sy2) * 0.5
+          switch (gradType) {
+            case 'horizontal':
+              gradientT = mx / width
+              break
+            case 'vertical':
+              gradientT = my / height
+              break
+            case 'radial': {
+              const rdx = mx - halfW
+              const rdy = my - halfH
+              gradientT = Math.sqrt(rdx * rdx + rdy * rdy) / radialMaxDist
+              break
+            }
+            case 'angular':
+              gradientT = (Math.atan2(my - halfH, mx - halfW) + PI) / (PI * 2)
+              break
+            default:
+              gradientT = midT
+          }
+        }
+
+        const [r, g, b] = lerpParsedStops(gradientT, parsedStops)
+
+        let strokeWidth: number
+        if (hasTaper) {
+          const taperCurve = Math.sin(midT * PI)
+          strokeWidth = Math.max(0.5, baseWeight * (1 - taperAmount + taperAmount * taperCurve))
+        } else {
+          strokeWidth = baseWeight
+        }
+
+        svg += `    <line x1="${round2(sx1)}" y1="${round2(sy1)}" x2="${round2(sx2)}" y2="${round2(sy2)}" stroke="rgb(${r},${g},${b})" stroke-width="${round2(strokeWidth)}" stroke-linecap="round"/>\n`
+      }
+    }
+  }
+
+  svg += `  </g>\n`
+  svg += `</svg>`
+  return svg
+}

--- a/src/tools/organic/types.ts
+++ b/src/tools/organic/types.ts
@@ -1,5 +1,8 @@
 import type { ColorStop } from '@/types/tools'
 
+export type PathPoint = { x: number; y: number }
+export type OrganicGeometry = { paths: PathPoint[][]; width: number; height: number }
+
 export type FlowFieldSettings = {
   noiseScale: number
   turbulence: number

--- a/src/tools/plotter/index.tsx
+++ b/src/tools/plotter/index.tsx
@@ -1,7 +1,9 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import type { RefObject } from 'react'
+import type p5 from 'p5'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVG, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -14,7 +16,8 @@ import { Button } from '@/components/ui/button'
 import { useShortcutActions } from '@/hooks/use-shortcut-actions'
 import { Kbd } from '@/components/ui/kbd'
 import { createPlotterSketch, PALETTES } from './sketch'
-import type { PlotterSettings } from './types'
+import { generatePlotterSvg } from './svg'
+import type { PlotterSettings, PlotterGeometry } from './types'
 
 const BG_COLORS = ['#f5f5dc', '#faf0e6', '#fff8e7', '#f0f0f0', '#1a1a1a', '#0d0d0d', '#f5f5f5', '#e8e4d9']
 
@@ -77,9 +80,15 @@ const showBrushControls = (t: string) => t === 'flowField' || t === 'concentric'
 
 export default function Plotter() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const geometryRef = useRef<PlotterGeometry | null>(null)
   const [settings, update, reset] = useSettings<PlotterSettings>('plotter', DEFAULTS)
-  const p5Ref = useP5(containerRef, createPlotterSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  const sketchFn = useCallback(
+    (p: p5, settingsRef: RefObject<PlotterSettings>) => createPlotterSketch(p, settingsRef, geometryRef),
+    [],
+  )
+  const p5Ref = useP5(containerRef, sketchFn, settings)
+  const hasRasterEffects = settings.textureAmount > 0
+  useShortcutActions({ randomize, reset, download: hasRasterEffects ? handleExportPNG : handleExportSVG })
 
   function handlePaletteChange(name: string) {
     if (name === 'custom') {
@@ -194,7 +203,14 @@ export default function Plotter() {
     })
   }
 
-  function download() {
+  function handleExportSVG() {
+    const geo = geometryRef.current
+    if (!geo) return
+    const svg = generatePlotterSvg(geo)
+    if (svg) exportSVG(svg, generateFilename('plotter', 'svg'))
+  }
+
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) exportPNG(canvas, generateFilename('plotter', 'png'))
   }
@@ -205,7 +221,17 @@ export default function Plotter() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          {hasRasterEffects ? (
+            <>
+              <Button variant="primary" onClick={handleExportPNG}>Export PNG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportSVG}>Export SVG</Button>
+            </>
+          ) : (
+            <>
+              <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
+            </>
+          )}
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Plotter</h2>

--- a/src/tools/plotter/sketch.ts
+++ b/src/tools/plotter/sketch.ts
@@ -1,10 +1,21 @@
 import type p5 from 'p5'
 import type { RefObject } from 'react'
-import type { PlotterSettings } from './types'
+import type {
+  PlotterGeometry,
+  PlotterPathPrimitive,
+  PlotterPrimitiveShapeType,
+  PlotterSettings,
+  PlotterShapePrimitive,
+} from './types'
 
 interface Point {
   x: number
   y: number
+}
+
+type ExportStyle = {
+  color: string
+  filled: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,8 +36,73 @@ export const PALETTES: Record<string, string[]> = {
   pastels: ['#b39ddb', '#ce93d8', '#f8bbd9'],
 }
 
-export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSettings>) {
+export function createPlotterSketch(
+  p: p5,
+  settingsRef: RefObject<PlotterSettings>,
+  geometryRef?: RefObject<PlotterGeometry | null>,
+) {
   const ctx = () => p.drawingContext as CanvasRenderingContext2D
+  let svgElements: (PlotterShapePrimitive | PlotterPathPrimitive)[] = []
+  // Track current transform for converting local-space organic path points to world space
+  let activeTransform: { tx: number; ty: number; rot: number } | null = null
+
+  function toWorldSpace(pt: Point): Point {
+    if (!activeTransform) return { x: pt.x, y: pt.y }
+    const { tx, ty, rot } = activeTransform
+    const rad = (rot * Math.PI) / 180
+    const cos = Math.cos(rad)
+    const sin = Math.sin(rad)
+    return {
+      x: tx + pt.x * cos - pt.y * sin,
+      y: ty + pt.x * sin + pt.y * cos,
+    }
+  }
+
+  function toWorldRotation(rotationDegrees: number): number {
+    return rotationDegrees + (activeTransform?.rot ?? 0)
+  }
+
+  function pushPathPrimitive(
+    points: Point[],
+    closed: boolean,
+    color: string,
+    strokeWeight: number,
+    filled: boolean,
+  ) {
+    if (points.length < 2) return
+    svgElements.push({
+      type: 'path',
+      points: points.map(pt => toWorldSpace(pt)),
+      closed,
+      color,
+      strokeWeight,
+      filled,
+    })
+  }
+
+  function pushShapePrimitive(
+    shapeType: PlotterPrimitiveShapeType,
+    x: number,
+    y: number,
+    size: number,
+    color: string,
+    rotationDegrees: number,
+    filled: boolean,
+    strokeWeight: number,
+  ) {
+    const world = toWorldSpace({ x, y })
+    svgElements.push({
+      type: 'shape',
+      shapeType,
+      x: world.x,
+      y: world.y,
+      size,
+      color,
+      rotation: toWorldRotation(rotationDegrees),
+      filled,
+      strokeWeight,
+    })
+  }
 
   function getContainerSize(): { w: number; h: number } {
     const el = (p as P5Any).canvas?.parentElement ?? document.body
@@ -60,6 +136,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
 
   function redrawCanvas() {
     const s = settingsRef.current
+    svgElements = []
 
     const target = getContainerSize()
     if (p.width !== target.w || p.height !== target.h) {
@@ -95,6 +172,16 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
 
     if (s.textureAmount > 0) {
       drawTexture(s)
+    }
+
+    if (geometryRef) {
+      geometryRef.current = {
+        elements: svgElements,
+        bgColor: s.bgColor,
+        width: p.width,
+        height: p.height,
+        margin: s.margin,
+      }
     }
   }
 
@@ -163,7 +250,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       }
 
       if (points.length > 1) {
-        renderBrushPath(s, points, false)
+        renderBrushPath(s, points, false, { color: colors[colorIndex], filled: false })
       }
     }
   }
@@ -201,7 +288,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         })
       }
 
-      renderBrushPath(s, points, true)
+      renderBrushPath(s, points, true, { color: colors[colorIndex], filled: false })
     }
   }
 
@@ -230,7 +317,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         points.push({ x, y: baseY + wave + noiseOffset })
       }
 
-      renderBrushPath(s, points, false)
+      renderBrushPath(s, points, false, { color: colors[colorIndex], filled: false })
     }
   }
 
@@ -287,7 +374,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         renderBrushPath(s, [
           { x: clipped.x1, y: clipped.y1 },
           { x: clipped.x2, y: clipped.y2 },
-        ], false)
+        ], false, { color: colors[colorIndex], filled: false })
       }
     }
   }
@@ -392,8 +479,11 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     p.push()
     p.translate(x, y)
     p.rotate((s.rotation * Math.PI) / 180)
+    activeTransform = { tx: x, ty: y, rot: s.rotation }
 
     const hasOrganic = s.wobble > 0 || s.roughness > 0
+    const exportFilled = s.filled && s.shapeType !== 'line' && s.shapeType !== 'cross' && s.shapeType !== 'ring'
+    const exportStyle: ExportStyle = { color, filled: exportFilled }
 
     if (s.filled) {
       p.fill(color)
@@ -404,27 +494,33 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       p.strokeWeight(s.strokeWeight)
     }
 
+    // For non-organic shapes, push a shape primitive for SVG export
+    if (!hasOrganic) {
+      pushShapePrimitive(s.shapeType, 0, 0, size, color, 0, exportFilled, s.strokeWeight)
+    }
+    // Organic shapes go through renderBrushPath which pushes path primitives
+
     switch (s.shapeType) {
       case 'circle':
-        if (hasOrganic) drawOrganicEllipse(s, 0, 0, size, size, x, y)
+        if (hasOrganic) drawOrganicEllipse(s, 0, 0, size, size, x, y, exportStyle)
         else p.ellipse(0, 0, size, size)
         break
       case 'square':
-        if (hasOrganic) drawOrganicRect(s, 0, 0, size, size, x, y)
+        if (hasOrganic) drawOrganicRect(s, 0, 0, size, size, x, y, exportStyle)
         else { p.rectMode(p.CENTER); p.rect(0, 0, size, size) }
         break
       case 'line':
         p.stroke(color)
         p.strokeWeight(s.strokeWeight)
-        if (hasOrganic) drawOrganicLine(s, -size / 2, 0, size / 2, 0, x, y)
+        if (hasOrganic) drawOrganicLine(s, -size / 2, 0, size / 2, 0, x, y, { color, filled: false })
         else p.line(-size / 2, 0, size / 2, 0)
         break
       case 'cross':
         p.stroke(color)
         p.strokeWeight(s.strokeWeight)
         if (hasOrganic) {
-          drawOrganicLine(s, -size / 2, 0, size / 2, 0, x, y)
-          drawOrganicLine(s, 0, -size / 2, 0, size / 2, x, y + 1000)
+          drawOrganicLine(s, -size / 2, 0, size / 2, 0, x, y, { color, filled: false })
+          drawOrganicLine(s, 0, -size / 2, 0, size / 2, x, y + 1000, { color, filled: false })
         } else {
           p.line(-size / 2, 0, size / 2, 0)
           p.line(0, -size / 2, 0, size / 2)
@@ -434,7 +530,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         p.noFill()
         p.stroke(color)
         p.strokeWeight(s.strokeWeight)
-        if (hasOrganic) drawOrganicEllipse(s, 0, 0, size, size, x, y)
+        if (hasOrganic) drawOrganicEllipse(s, 0, 0, size, size, x, y, { color, filled: false })
         else p.ellipse(0, 0, size, size)
         break
       case 'diamond':
@@ -444,7 +540,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
             { x: size / 2, y: 0 },
             { x: 0, y: size / 2 },
             { x: -size / 2, y: 0 },
-          ], x, y)
+          ], x, y, exportStyle)
         } else {
           p.beginShape()
           p.vertex(0, -size / 2)
@@ -456,6 +552,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         break
     }
 
+    activeTransform = null
     p.pop()
   }
 
@@ -479,7 +576,16 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     return { x: px + offsetX, y: py + offsetY }
   }
 
-  function drawOrganicEllipse(s: PlotterSettings, cx: number, cy: number, w: number, h: number, seedX: number, seedY: number) {
+  function drawOrganicEllipse(
+    s: PlotterSettings,
+    cx: number,
+    cy: number,
+    w: number,
+    h: number,
+    seedX: number,
+    seedY: number,
+    style: ExportStyle,
+  ) {
     const segments = Math.max(12, Math.floor(Math.max(w, h) * 0.8))
     const points: Point[] = []
     for (let i = 0; i < segments; i++) {
@@ -488,10 +594,19 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       const py = cy + Math.sin(angle) * h / 2
       points.push(applyWobble(s, px, py, seedX + i * 0.1, seedY + i * 0.1))
     }
-    renderBrushPath(s, points, true)
+    renderBrushPath(s, points, true, style)
   }
 
-  function drawOrganicRect(s: PlotterSettings, cx: number, cy: number, w: number, h: number, seedX: number, seedY: number) {
+  function drawOrganicRect(
+    s: PlotterSettings,
+    cx: number,
+    cy: number,
+    w: number,
+    h: number,
+    seedX: number,
+    seedY: number,
+    style: ExportStyle,
+  ) {
     const segs = Math.max(4, Math.floor(Math.max(w, h) * 0.2))
     const points: Point[] = []
 
@@ -512,10 +627,19 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       points.push(applyWobble(s, cx - w / 2, cy + h / 2 - t * h, seedX + 300, seedY))
     }
 
-    renderBrushPath(s, points, true)
+    renderBrushPath(s, points, true, style)
   }
 
-  function drawOrganicLine(s: PlotterSettings, x1: number, y1: number, x2: number, y2: number, seedX: number, seedY: number) {
+  function drawOrganicLine(
+    s: PlotterSettings,
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    seedX: number,
+    seedY: number,
+    style: ExportStyle,
+  ) {
     const d = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
     const segments = Math.max(4, Math.floor(d * 0.3))
     const points: Point[] = []
@@ -528,13 +652,19 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     }
 
     if (s.brushType === 'normal' && s.strokeTaper > 0) {
-      renderTaperedPath(s, points)
+      renderTaperedPath(s, points, style)
     } else {
-      renderBrushPath(s, points, false)
+      renderBrushPath(s, points, false, style)
     }
   }
 
-  function drawOrganicPolygon(s: PlotterSettings, inputPoints: Point[], seedX: number, seedY: number) {
+  function drawOrganicPolygon(
+    s: PlotterSettings,
+    inputPoints: Point[],
+    seedX: number,
+    seedY: number,
+    style: ExportStyle,
+  ) {
     const segs = Math.max(3, Math.floor(s.wobble + s.roughness) + 2)
     const points: Point[] = []
 
@@ -550,35 +680,37 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       }
     }
 
-    renderBrushPath(s, points, true)
+    renderBrushPath(s, points, true, style)
   }
 
   // ── Brush System ──
 
-  function renderBrushPath(s: PlotterSettings, points: Point[], closed: boolean) {
+  function renderBrushPath(s: PlotterSettings, points: Point[], closed: boolean, style: ExportStyle) {
     if (points.length < 2) return
 
     switch (s.brushType) {
       case 'stippled':
-        renderStippledPath(s, points, closed)
+        renderStippledPath(s, points, closed, style)
         break
       case 'multiStroke':
-        renderMultiStrokePath(s, points, closed)
+        renderMultiStrokePath(s, points, closed, style)
         break
       case 'calligraphic':
-        renderCalligraphicPath(s, points, closed)
+        renderCalligraphicPath(s, points, closed, style)
         break
       case 'stamp':
-        renderStampPath(s, points, closed)
+        renderStampPath(s, points, closed, style)
         break
       case 'normal':
       default:
-        renderNormalPath(points, closed)
+        renderNormalPath(points, closed, style, s.strokeWeight)
         break
     }
   }
 
-  function renderNormalPath(points: Point[], closed: boolean) {
+  function renderNormalPath(points: Point[], closed: boolean, style: ExportStyle, strokeWeight: number) {
+    pushPathPrimitive(points, closed, style.color, strokeWeight, style.filled && closed)
+
     p.beginShape()
     for (const pt of points) {
       p.vertex(pt.x, pt.y)
@@ -586,14 +718,17 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     p.endShape(closed ? p.CLOSE : undefined)
   }
 
-  function renderTaperedPath(s: PlotterSettings, points: Point[]) {
+  function renderTaperedPath(s: PlotterSettings, points: Point[], style: ExportStyle) {
     const baseWeight = s.strokeWeight
     const taper = s.strokeTaper
+    p.noFill()
+    p.stroke(style.color)
 
     for (let i = 0; i < points.length - 1; i++) {
       const t = (i + 0.5) / (points.length - 1)
       const taperAmount = Math.sin(t * Math.PI)
       const weight = baseWeight * (1 - taper + taper * taperAmount)
+      pushPathPrimitive([points[i], points[i + 1]], false, style.color, weight, false)
       p.strokeWeight(weight)
       p.line(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y)
     }
@@ -601,15 +736,12 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     p.strokeWeight(baseWeight)
   }
 
-  function renderStippledPath(s: PlotterSettings, points: Point[], closed: boolean) {
+  function renderStippledPath(s: PlotterSettings, points: Point[], closed: boolean, style: ExportStyle) {
     const spacing = s.stippled.dotSpacing
     const baseSize = s.stippled.dotSize
     const variation = s.stippled.sizeVariation
     const isDash = s.stippled.dash
     const dashLength = s.stippled.dashLength
-
-    const c = ctx()
-    const currentStroke = c.strokeStyle
 
     let accumulated = 0
     const totalPoints = closed ? points.length : points.length - 1
@@ -630,15 +762,20 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         if (isDash) {
           const dx = Math.cos(angle) * dashLength / 2
           const dy = Math.sin(angle) * dashLength / 2
+          pushPathPrimitive([
+            { x: x - dx, y: y - dy },
+            { x: x + dx, y: y + dy },
+          ], false, style.color, s.strokeWeight, false)
           p.push()
-          p.stroke(currentStroke as string)
+          p.stroke(style.color)
           p.strokeWeight(s.strokeWeight)
           p.line(x - dx, y - dy, x + dx, y + dy)
           p.pop()
         } else {
+          pushShapePrimitive('circle', x, y, size, style.color, 0, true, 0)
           p.push()
           p.noStroke()
-          p.fill(currentStroke as string)
+          p.fill(style.color)
           p.ellipse(x, y, size, size)
           p.pop()
         }
@@ -649,7 +786,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     }
   }
 
-  function renderMultiStrokePath(s: PlotterSettings, points: Point[], closed: boolean) {
+  function renderMultiStrokePath(s: PlotterSettings, points: Point[], closed: boolean, style: ExportStyle) {
     const count = s.multiStroke.count
     const spread = s.multiStroke.spread
     const variation = s.multiStroke.variation
@@ -658,6 +795,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
 
     for (let si = 0; si < count; si++) {
       const baseOffset = count > 1 ? ((si / (count - 1)) - 0.5) * spread : 0
+      const offsetPoints: Point[] = []
 
       p.beginShape()
       for (let i = 0; i < points.length; i++) {
@@ -665,21 +803,21 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         const n = normals[i]
         const varOffset = (p.random() - 0.5) * variation * spread
         const totalOffset = baseOffset + varOffset
-        p.vertex(pt.x + n.x * totalOffset, pt.y + n.y * totalOffset)
+        const offsetPoint = { x: pt.x + n.x * totalOffset, y: pt.y + n.y * totalOffset }
+        offsetPoints.push(offsetPoint)
+        p.vertex(offsetPoint.x, offsetPoint.y)
       }
       p.endShape(closed ? p.CLOSE : undefined)
+      pushPathPrimitive(offsetPoints, closed, style.color, s.strokeWeight, style.filled && closed)
     }
   }
 
-  function renderCalligraphicPath(s: PlotterSettings, points: Point[], _closed: boolean) {
+  function renderCalligraphicPath(s: PlotterSettings, points: Point[], _closed: boolean, style: ExportStyle) {
     const penAngle = (s.calligraphic.angle * Math.PI) / 180
     const minWidth = s.calligraphic.minWidth
     const maxWidth = s.calligraphic.maxWidth
     const smoothing = s.calligraphic.smoothing
     const baseWeight = s.strokeWeight
-
-    const c = ctx()
-    const currentStroke = c.strokeStyle
 
     const leftEdge: Point[] = []
     const rightEdge: Point[] = []
@@ -711,9 +849,13 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
       rightEdge.push({ x: points[i].x + ox, y: points[i].y + oy })
     }
 
+    // Capture calligraphic shape as a filled path for SVG
+    const calliPoints: Point[] = [...leftEdge, ...rightEdge.slice().reverse()]
+    pushPathPrimitive(calliPoints, true, style.color, 0, true)
+
     p.push()
     p.noStroke()
-    p.fill(currentStroke as string)
+    p.fill(style.color)
     p.beginShape()
     for (const pt of leftEdge) p.vertex(pt.x, pt.y)
     for (let i = rightEdge.length - 1; i >= 0; i--) p.vertex(rightEdge[i].x, rightEdge[i].y)
@@ -721,7 +863,7 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     p.pop()
   }
 
-  function renderStampPath(s: PlotterSettings, points: Point[], closed: boolean) {
+  function renderStampPath(s: PlotterSettings, points: Point[], closed: boolean, style: ExportStyle) {
     const spacing = s.stamp.spacing
     const baseSize = s.stamp.size
     const sizeVar = s.stamp.sizeVariation
@@ -729,9 +871,6 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
     const rotVar = (s.stamp.rotationVariation * Math.PI) / 180
     const scatter = s.stamp.scatter
     const shape = s.stamp.shape
-
-    const c = ctx()
-    const currentStroke = c.strokeStyle
 
     let accumulated = 0
     const totalPoints = closed ? points.length : points.length - 1
@@ -758,7 +897,8 @@ export function createPlotterSketch(p: p5, settingsRef: RefObject<PlotterSetting
         const size = baseSize * (1 + (p.random() - 0.5) * sizeVar * 2)
         const rot = baseRotation + (p.random() - 0.5) * rotVar * 2
 
-        drawStampShape(x, y, size, rot, shape, currentStroke as string)
+        pushShapePrimitive(shape, x, y, size, style.color, (rot * 180) / Math.PI, true, 0)
+        drawStampShape(x, y, size, rot, shape, style.color)
 
         pos += spacing
       }

--- a/src/tools/plotter/svg.ts
+++ b/src/tools/plotter/svg.ts
@@ -1,0 +1,169 @@
+import type {
+  PlotterGeometry,
+  PlotterPathPrimitive,
+  PlotterPoint,
+  PlotterShapePrimitive,
+} from './types'
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function pointsToPolyString(points: PlotterPoint[]): string {
+  return points.map(pt => `${round2(pt.x)},${round2(pt.y)}`).join(' ')
+}
+
+function regularStarPoints(x: number, y: number, innerRadius: number, outerRadius: number): PlotterPoint[] {
+  const points: PlotterPoint[] = []
+  const angle = Math.PI / 5
+  for (let i = 0; i < 10; i++) {
+    const radius = i % 2 === 0 ? outerRadius : innerRadius
+    const theta = -Math.PI / 2 + i * angle
+    points.push({
+      x: x + Math.cos(theta) * radius,
+      y: y + Math.sin(theta) * radius,
+    })
+  }
+  return points
+}
+
+function renderShapePrimitive(el: PlotterShapePrimitive): string {
+  const { shapeType, x, y, size, color, rotation, filled, strokeWeight } = el
+  const half = size / 2
+  const fillAttr = filled ? `fill="${color}"` : `fill="none"`
+  const strokeAttr = filled ? '' : ` stroke="${color}" stroke-width="${round2(strokeWeight)}"`
+  const rotAttr = rotation !== 0 ? ` transform="rotate(${round2(rotation)},${round2(x)},${round2(y)})"` : ''
+
+  switch (shapeType) {
+    case 'circle':
+      return `    <circle cx="${round2(x)}" cy="${round2(y)}" r="${round2(half)}" ${fillAttr}${strokeAttr}${rotAttr}/>\n`
+
+    case 'square':
+      return `    <rect x="${round2(x - half)}" y="${round2(y - half)}" width="${round2(size)}" height="${round2(size)}" ${fillAttr}${strokeAttr}${rotAttr}/>\n`
+
+    case 'triangle': {
+      const height = size * 0.866
+      const pts = [
+        { x, y: y - height / 2 },
+        { x: x - half, y: y + height / 2 },
+        { x: x + half, y: y + height / 2 },
+      ]
+      return `    <polygon points="${pointsToPolyString(pts)}" ${fillAttr}${strokeAttr}${rotAttr}/>\n`
+    }
+
+    case 'diamond': {
+      const pts = [
+        { x, y: y - half },
+        { x: x + half, y },
+        { x, y: y + half },
+        { x: x - half, y },
+      ]
+      return `    <polygon points="${pointsToPolyString(pts)}" ${fillAttr}${strokeAttr}${rotAttr}/>\n`
+    }
+
+    case 'cross': {
+      if (filled) {
+        const arm = size / 4
+        const armHalf = arm / 2
+        const pts = [
+          { x: x - half, y: y - armHalf },
+          { x: x - armHalf, y: y - armHalf },
+          { x: x - armHalf, y: y - half },
+          { x: x + armHalf, y: y - half },
+          { x: x + armHalf, y: y - armHalf },
+          { x: x + half, y: y - armHalf },
+          { x: x + half, y: y + armHalf },
+          { x: x + armHalf, y: y + armHalf },
+          { x: x + armHalf, y: y + half },
+          { x: x - armHalf, y: y + half },
+          { x: x - armHalf, y: y + armHalf },
+          { x: x - half, y: y + armHalf },
+        ]
+        return `    <polygon points="${pointsToPolyString(pts)}" fill="${color}" stroke="none"${rotAttr}/>\n`
+      }
+
+      const cos = Math.cos((rotation * Math.PI) / 180)
+      const sin = Math.sin((rotation * Math.PI) / 180)
+      // Horizontal arm
+      const hx1 = x + (-half) * cos
+      const hy1 = y + (-half) * sin
+      const hx2 = x + half * cos
+      const hy2 = y + half * sin
+      // Vertical arm
+      const vx1 = x + (-half) * -sin
+      const vy1 = y + (-half) * cos
+      const vx2 = x + half * -sin
+      const vy2 = y + half * cos
+      return `    <line x1="${round2(hx1)}" y1="${round2(hy1)}" x2="${round2(hx2)}" y2="${round2(hy2)}" stroke="${color}" stroke-width="${round2(strokeWeight)}"/>\n` +
+             `    <line x1="${round2(vx1)}" y1="${round2(vy1)}" x2="${round2(vx2)}" y2="${round2(vy2)}" stroke="${color}" stroke-width="${round2(strokeWeight)}"/>\n`
+    }
+
+    case 'ring':
+      return `    <circle cx="${round2(x)}" cy="${round2(y)}" r="${round2(half)}" fill="none" stroke="${color}" stroke-width="${round2(strokeWeight)}"${rotAttr}/>\n`
+
+    case 'star': {
+      const pts = regularStarPoints(x, y, size / 4, half)
+      return `    <polygon points="${pointsToPolyString(pts)}" ${fillAttr}${strokeAttr}${rotAttr}/>\n`
+    }
+
+    case 'line': {
+      const cos = Math.cos((rotation * Math.PI) / 180)
+      const sin = Math.sin((rotation * Math.PI) / 180)
+      const lx1 = x + (-half) * cos
+      const ly1 = y + (-half) * sin
+      const lx2 = x + half * cos
+      const ly2 = y + half * sin
+      return `    <line x1="${round2(lx1)}" y1="${round2(ly1)}" x2="${round2(lx2)}" y2="${round2(ly2)}" stroke="${color}" stroke-width="${round2(strokeWeight)}"/>\n`
+    }
+
+    default:
+      return ''
+  }
+}
+
+function renderPathPrimitive(el: PlotterPathPrimitive): string {
+  if (el.points.length < 2) return ''
+
+  const { points, closed, color, strokeWeight, filled } = el
+
+  if (filled && closed) {
+    return `    <polygon points="${pointsToPolyString(points)}" fill="${color}" stroke="none"/>\n`
+  }
+
+  if (closed) {
+    return `    <polygon points="${pointsToPolyString(points)}" fill="none" stroke="${color}" stroke-width="${round2(strokeWeight)}" stroke-linecap="round" stroke-linejoin="round"/>\n`
+  }
+
+  return `    <polyline points="${pointsToPolyString(points)}" fill="none" stroke="${color}" stroke-width="${round2(strokeWeight)}" stroke-linecap="round" stroke-linejoin="round"/>\n`
+}
+
+export function generatePlotterSvg(geometry: PlotterGeometry): string {
+  const { elements, bgColor, width, height, margin } = geometry
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n`
+  svg += `  <rect width="100%" height="100%" fill="${bgColor}"/>\n`
+
+  const hasClip = margin > 0
+  if (hasClip) {
+    svg += `  <defs>\n`
+    svg += `    <clipPath id="margin">\n`
+    svg += `      <rect x="${margin}" y="${margin}" width="${width - margin * 2}" height="${height - margin * 2}"/>\n`
+    svg += `    </clipPath>\n`
+    svg += `  </defs>\n`
+  }
+
+  const groupAttrs = hasClip ? ` clip-path="url(#margin)"` : ''
+  svg += `  <g${groupAttrs}>\n`
+
+  for (const el of elements) {
+    if (el.type === 'shape') {
+      svg += renderShapePrimitive(el)
+    } else {
+      svg += renderPathPrimitive(el)
+    }
+  }
+
+  svg += `  </g>\n`
+  svg += `</svg>`
+  return svg
+}

--- a/src/tools/plotter/types.ts
+++ b/src/tools/plotter/types.ts
@@ -1,3 +1,44 @@
+export type PlotterPoint = { x: number; y: number }
+
+export type PlotterPrimitiveShapeType =
+  | 'circle'
+  | 'square'
+  | 'triangle'
+  | 'star'
+  | 'cross'
+  | 'ring'
+  | 'line'
+  | 'diamond'
+
+export type PlotterShapePrimitive = {
+  type: 'shape'
+  shapeType: PlotterPrimitiveShapeType
+  x: number
+  y: number
+  size: number
+  color: string
+  rotation: number
+  filled: boolean
+  strokeWeight: number
+}
+
+export type PlotterPathPrimitive = {
+  type: 'path'
+  points: PlotterPoint[]
+  closed: boolean
+  color: string
+  strokeWeight: number
+  filled: boolean
+}
+
+export type PlotterGeometry = {
+  elements: (PlotterShapePrimitive | PlotterPathPrimitive)[]
+  bgColor: string
+  width: number
+  height: number
+  margin: number
+}
+
 export type StippledSettings = {
   dotSpacing: number
   dotSize: number

--- a/src/tools/topo/index.tsx
+++ b/src/tools/topo/index.tsx
@@ -1,7 +1,9 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
+import type { RefObject } from 'react'
+import type p5 from 'p5'
 import { useSettings } from '@/hooks/use-settings'
 import { useP5 } from '@/hooks/use-p5'
-import { exportPNG, generateFilename } from '@/lib/export'
+import { exportPNG, exportSVG, generateFilename } from '@/lib/export'
 import { CanvasArea } from '@/components/canvas-area'
 import { Sidebar } from '@/components/sidebar'
 import { Section } from '@/components/controls/section'
@@ -13,7 +15,8 @@ import { Button } from '@/components/ui/button'
 import { useShortcutActions } from '@/hooks/use-shortcut-actions'
 import { Kbd } from '@/components/ui/kbd'
 import { createTopoSketch } from './sketch'
-import type { TopoSettings } from './types'
+import { generateTopoSvg } from './svg'
+import type { TopoSettings, TopoGeometry } from './types'
 
 const DEFAULTS: TopoSettings = {
   seed: 12345,
@@ -55,9 +58,15 @@ function randomColor(): string {
 
 export default function Topo() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const geometryRef = useRef<TopoGeometry | null>(null)
   const [settings, update, reset] = useSettings<TopoSettings>('topo', DEFAULTS)
-  const p5Ref = useP5(containerRef, createTopoSketch, settings)
-  useShortcutActions({ randomize, reset, download })
+  const sketchFn = useCallback(
+    (p: p5, settingsRef: RefObject<TopoSettings>) => createTopoSketch(p, settingsRef, geometryRef),
+    [],
+  )
+  const p5Ref = useP5(containerRef, sketchFn, settings)
+  const hasRasterEffects = settings.grain > 0
+  useShortcutActions({ randomize, reset, download: hasRasterEffects ? handleExportPNG : handleExportSVG })
 
   function randomize() {
     const paletteNames = ['mono', 'topo', 'ocean', 'earth', 'sunset', 'forest', 'heat']
@@ -108,7 +117,14 @@ export default function Topo() {
     })
   }
 
-  function download() {
+  function handleExportSVG() {
+    const geo = geometryRef.current
+    if (!geo) return
+    const svg = generateTopoSvg(geo, settings)
+    if (svg) exportSVG(svg, generateFilename('topo', 'svg'))
+  }
+
+  function handleExportPNG() {
     const canvas = (p5Ref.current as unknown as { canvas: HTMLCanvasElement })?.canvas
     if (canvas) {
       exportPNG(canvas, generateFilename('topo', 'png'))
@@ -121,7 +137,17 @@ export default function Topo() {
         <ButtonRow>
           <Button variant="secondary" onClick={randomize}>Randomize <Kbd>R</Kbd></Button>
           <Button variant="secondary" onClick={reset}>Reset <Kbd>⌫</Kbd></Button>
-          <Button variant="primary" onClick={download}>Download PNG <Kbd>⌘S</Kbd></Button>
+          {hasRasterEffects ? (
+            <>
+              <Button variant="primary" onClick={handleExportPNG}>Export PNG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportSVG}>Export SVG</Button>
+            </>
+          ) : (
+            <>
+              <Button variant="primary" onClick={handleExportSVG}>Export SVG <Kbd>⌘S</Kbd></Button>
+              <Button variant="secondary" onClick={handleExportPNG}>Export PNG</Button>
+            </>
+          )}
         </ButtonRow>
       }>
         <h2 className="mb-3 text-base font-medium text-text-primary">Topo</h2>

--- a/src/tools/topo/sketch.ts
+++ b/src/tools/topo/sketch.ts
@@ -1,11 +1,11 @@
 import type p5 from 'p5'
 import type { RefObject } from 'react'
-import type { TopoSettings } from './types'
+import type { TopoSettings, Point, ContourPath, TopoGeometry } from './types'
 import { hexToRgb } from '@/lib/color'
 
 const GRID_SIZE = 200
 
-const PALETTES: Record<string, string[]> = {
+export const PALETTES: Record<string, string[]> = {
   mono: ['#000000', '#333333', '#666666', '#999999', '#cccccc'],
   topo: ['#264653', '#2a9d8f', '#e9c46a', '#f4a261', '#e76f51'],
   ocean: ['#03045e', '#0077b6', '#00b4d8', '#90e0ef', '#caf0f8'],
@@ -15,26 +15,20 @@ const PALETTES: Record<string, string[]> = {
   heat: ['#03071e', '#370617', '#6a040f', '#d00000', '#dc2f02', '#e85d04', '#f48c06', '#faa307', '#ffba08'],
 }
 
-interface Point {
-  x: number
-  y: number
-}
-
 interface Segment {
   p1: Point
   p2: Point
   level: number
 }
 
-interface ContourPath {
-  points: Point[]
-  level: number
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type P5Any = any
 
-export function createTopoSketch(p: p5, settingsRef: RefObject<TopoSettings>) {
+export function createTopoSketch(
+  p: p5,
+  settingsRef: RefObject<TopoSettings>,
+  geometryRef?: RefObject<TopoGeometry | null>,
+) {
   let elevationField: number[][] = []
   let contours: ContourPath[] = []
   const ctx = () => p.drawingContext as CanvasRenderingContext2D
@@ -291,13 +285,20 @@ export function createTopoSketch(p: p5, settingsRef: RefObject<TopoSettings>) {
     p.strokeCap(p.ROUND)
     p.strokeJoin(p.ROUND)
 
+    const renderedContours: ContourPath[] = []
+
     for (const contour of contours) {
-      renderContour(contour, s)
+      const rendered = renderContour(contour, s)
+      if (rendered) renderedContours.push(rendered)
+    }
+
+    if (geometryRef) {
+      geometryRef.current = { contours: renderedContours, width: p.width, height: p.height }
     }
   }
 
-  function renderContour(contour: ContourPath, s: TopoSettings) {
-    if (contour.points.length < 2) return
+  function renderContour(contour: ContourPath, s: TopoSettings): ContourPath | null {
+    if (contour.points.length < 2) return null
 
     if (s.colorMode === 'single') {
       const rgb = hexToRgb(s.lineColor || '#222222')
@@ -323,6 +324,8 @@ export function createTopoSketch(p: p5, settingsRef: RefObject<TopoSettings>) {
     } else {
       drawPath(points)
     }
+
+    return { points, level: contour.level }
   }
 
   function getContourColor(level: number, s: TopoSettings): p5.Color {

--- a/src/tools/topo/svg.ts
+++ b/src/tools/topo/svg.ts
@@ -1,0 +1,106 @@
+import type { TopoSettings, TopoGeometry, Point } from './types'
+import { lerpColor } from '@/lib/color'
+import { PALETTES } from './sketch'
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+function getContourColorHex(level: number, s: TopoSettings): string {
+  switch (s.colorMode) {
+    case 'elevation': {
+      const col = lerpColor(s.lineColor || '#222222', s.bgColor, level * 0.7)
+      return col
+    }
+    case 'palette': {
+      const pal = PALETTES[s.palette] || PALETTES.mono
+      const palIndex = Math.floor(level * (pal.length - 1))
+      const palT = (level * (pal.length - 1)) % 1
+      const c1 = pal[Math.min(palIndex, pal.length - 1)]
+      const c2 = pal[Math.min(palIndex + 1, pal.length - 1)]
+      return lerpColor(c1, c2, palT)
+    }
+    default:
+      return s.lineColor || '#222222'
+  }
+}
+
+/** Convert Catmull-Rom spline points to SVG cubic bezier path data. */
+function catmullRomToSvgPath(points: Point[]): string {
+  if (points.length < 2) return ''
+  if (points.length === 2) {
+    return `M${round2(points[0].x)},${round2(points[0].y)} L${round2(points[1].x)},${round2(points[1].y)}`
+  }
+
+  // p5's splineVertex duplicates first and last points as control points
+  const pts = [points[0], ...points, points[points.length - 1]]
+
+  let d = `M${round2(pts[1].x)},${round2(pts[1].y)}`
+
+  for (let i = 0; i < pts.length - 3; i++) {
+    const p0 = pts[i]
+    const p1 = pts[i + 1]
+    const p2 = pts[i + 2]
+    const p3 = pts[i + 3]
+
+    // Catmull-Rom to cubic Bezier conversion
+    const cp1x = p1.x + (p2.x - p0.x) / 6
+    const cp1y = p1.y + (p2.y - p0.y) / 6
+    const cp2x = p2.x - (p3.x - p1.x) / 6
+    const cp2y = p2.y - (p3.y - p1.y) / 6
+
+    d += ` C${round2(cp1x)},${round2(cp1y)} ${round2(cp2x)},${round2(cp2y)} ${round2(p2.x)},${round2(p2.y)}`
+  }
+
+  return d
+}
+
+function pointsToSvgPath(points: Point[]): string {
+  if (points.length < 2) return ''
+  let d = `M${round2(points[0].x)},${round2(points[0].y)}`
+  for (let i = 1; i < points.length; i++) {
+    d += ` L${round2(points[i].x)},${round2(points[i].y)}`
+  }
+  return d
+}
+
+export function generateTopoSvg(
+  geometry: TopoGeometry,
+  settings: TopoSettings,
+): string {
+  const { contours, width, height } = geometry
+  const useSmoothing = settings.smoothing > 0
+
+  let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">\n`
+  svg += `  <rect width="100%" height="100%" fill="${settings.bgColor}"/>\n`
+
+  const pad = settings.margin
+  const hasClip = pad > 0
+
+  if (hasClip) {
+    svg += `  <defs>\n`
+    svg += `    <clipPath id="margin">\n`
+    svg += `      <rect x="${pad}" y="${pad}" width="${width - pad * 2}" height="${height - pad * 2}"/>\n`
+    svg += `    </clipPath>\n`
+    svg += `  </defs>\n`
+  }
+
+  const groupAttrs = hasClip ? ` clip-path="url(#margin)"` : ''
+  svg += `  <g fill="none" stroke-linecap="round" stroke-linejoin="round"${groupAttrs}>\n`
+
+  for (const contour of contours) {
+    if (contour.points.length < 2) continue
+
+    const color = getContourColorHex(contour.level, settings)
+    const opacity = settings.opacity / 100
+    const d = useSmoothing && contour.points.length > 2
+      ? catmullRomToSvgPath(contour.points)
+      : pointsToSvgPath(contour.points)
+
+    svg += `    <path d="${d}" stroke="${color}" stroke-width="${settings.strokeWeight}" stroke-opacity="${round2(opacity)}"/>\n`
+  }
+
+  svg += `  </g>\n`
+  svg += `</svg>`
+  return svg
+}

--- a/src/tools/topo/types.ts
+++ b/src/tools/topo/types.ts
@@ -1,3 +1,7 @@
+export type Point = { x: number; y: number }
+export type ContourPath = { points: Point[]; level: number }
+export type TopoGeometry = { contours: ContourPath[]; width: number; height: number }
+
 export type TopoSettings = {
   seed: number
   contourLevels: number


### PR DESCRIPTION
## Summary

Add SVG export functionality to four design tools (topo, blocks, organic, plotter) by extracting cached geometry and converting to vector SVG format. Each tool gets an svg.ts generator that outputs paths, shapes, and colors while skipping pixel-only effects like grain, texture, and halftone.

## Features

- **SVG generators** for each tool that preserve geometry and colors without raster effects
- **Dynamic button behavior**: PNG is primary when raster effects are active (grain/texture/halftone > 0), SVG is primary when inactive
- **Catmull-Rom to Bézier** conversion for smooth topo paths
- **Per-segment coloring** for organic tool with taper support
- **Deterministic geometry** re-derivation in blocks via seededRandom for accurate SVG matching

## Implementation

- Added geometry refs to sketches to expose cached/rendered data
- Created svg.ts modules with pure generator functions (no p5 dependency)
- Updated types.ts with shared geometry types
- UI shows both export options; primary button follows what's on screen

Fixes #2