### PR TITLE
Fix Marble tool high RAM usage during animation

### DIFF
--- a/src/tools/marble/engine.ts
+++ b/src/tools/marble/engine.ts
@@ -7,6 +7,7 @@ import { hexToRgb } from "@/lib/color"
 export type MarbleEngine = {
   canvas: HTMLCanvasElement
   resize: (w: number, h: number) => void
+  requestRender: () => void
   destroy: () => void
 }
 
@@ -109,20 +110,23 @@ export function createMarbleEngine(
     uVeinColor: gl.getUniformLocation(program, "uVeinColor"),
   }
 
-  let rafId = 0
+  const MIN_FRAME_INTERVAL = 1000 / 60 // Cap at 60fps
+
+  let animationRafId = 0
+  let renderRafId = 0
   let animTime = 0
   let lastFrameTime = performance.now()
+  let destroyed = false
 
-  function frame() {
+  function renderOneFrame(advanceTime: boolean) {
     const s = settingsRef.current
-    if (!s) { rafId = requestAnimationFrame(frame); return }
+    if (!s) return
 
-    const now = performance.now()
-    if (s.animated) {
+    if (advanceTime) {
+      const now = performance.now()
       animTime += ((now - lastFrameTime) / 1000) * s.speed * 0.85
+      lastFrameTime = now
     }
-    lastFrameTime = now
-    const elapsed = animTime
 
     gl.viewport(0, 0, canvas.width, canvas.height)
     gl.clearColor(0, 0, 0, 1)
@@ -130,7 +134,7 @@ export function createMarbleEngine(
 
     gl.useProgram(program)
 
-    gl.uniform1f(loc.uTime, elapsed)
+    gl.uniform1f(loc.uTime, animTime)
     gl.uniform2f(loc.uResolution, canvas.width, canvas.height)
 
     const main = hexToVec3(s.colorMain)
@@ -167,20 +171,73 @@ export function createMarbleEngine(
     if (recorderRef?.current) {
       recorderRef.current.addFrame(canvas)
     }
-
-    rafId = requestAnimationFrame(frame)
   }
 
-  rafId = requestAnimationFrame(frame)
+  function animationLoop() {
+    if (destroyed) return
+    const s = settingsRef.current
+    if (!s?.animated) {
+      // Animation was turned off — render final frame and stop
+      renderOneFrame(false)
+      animationRafId = 0
+      return
+    }
+
+    const now = performance.now()
+    if (now - lastFrameTime < MIN_FRAME_INTERVAL) {
+      animationRafId = requestAnimationFrame(animationLoop)
+      return
+    }
+
+    renderOneFrame(true)
+    animationRafId = requestAnimationFrame(animationLoop)
+  }
+
+  function requestRender() {
+    if (destroyed) return
+    const s = settingsRef.current
+    if (s?.animated) {
+      if (renderRafId) {
+        cancelAnimationFrame(renderRafId)
+        renderRafId = 0
+      }
+      // Start animation loop if not already running
+      if (!animationRafId) {
+        lastFrameTime = performance.now()
+        animationRafId = requestAnimationFrame(animationLoop)
+      }
+      return
+    }
+    if (animationRafId) {
+      cancelAnimationFrame(animationRafId)
+      animationRafId = 0
+    }
+    // Static mode — queue a single render, coalesced
+    if (renderRafId) return
+    renderRafId = requestAnimationFrame(() => {
+      renderRafId = 0
+      if (destroyed) return
+      renderOneFrame(false)
+    })
+  }
+
+  // Initial render
+  requestRender()
 
   return {
     canvas,
+    requestRender,
     resize(w: number, h: number) {
       canvas.width = w
       canvas.height = h
+      requestRender()
     },
     destroy() {
-      cancelAnimationFrame(rafId)
+      destroyed = true
+      cancelAnimationFrame(animationRafId)
+      cancelAnimationFrame(renderRafId)
+      animationRafId = 0
+      renderRafId = 0
       gl.deleteTexture(noiseTex)
       gl.deleteProgram(program)
       gl.deleteShader(vert)

--- a/src/tools/marble/index.tsx
+++ b/src/tools/marble/index.tsx
@@ -45,6 +45,11 @@ export default function Marble() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Re-render when settings change (starts/stops animation loop as needed)
+  useEffect(() => {
+    engineRef.current?.requestRender()
+  }, [settings])
+
   // Resize canvas when size settings change
   useEffect(() => {
     const [w, h] = resolveCanvasSize(settings.canvasPreset, settings.customWidth, settings.customHeight)


### PR DESCRIPTION
## Summary

- The Marble tool's WebGL2 render loop ran unconditionally at the display's full refresh rate (60-144fps), even when animation was disabled — causing sustained GPU memory pressure, high RAM usage (~4GB reported), and fan spin
- Replaced the always-on `requestAnimationFrame` loop with a dual-mode system: **static mode** renders a single frame on demand (re-renders only on settings change), **animated mode** runs the RAF loop capped at 60fps
- Added `requestRender()` to the engine API, wired to a `useEffect([settings])` in the React component to handle mode transitions and slider changes

## Test plan

- [ ] Open Marble tool with animation OFF — canvas renders, Activity Monitor shows low CPU/GPU, re-renders on slider changes
- [ ] Toggle animation ON — smooth animation, CPU stays reasonable
- [ ] Toggle animation OFF — loop stops (CPU drops), canvas retains last frame
- [ ] Start/stop MP4 recording — animation starts with recording, stops when recording ends
- [ ] Export PNG — confirm screenshot still works