### PR TITLE
Fix Safari MP4 recording stop button

### DIFF
--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -133,6 +133,7 @@ export function createRecorder(
 
       const frame = new VideoFrame(source, {
         timestamp: (frameCount / fps) * 1_000_000,
+        duration: Math.round(1_000_000 / fps),
       });
       encoder.encode(frame);
       frame.close();
@@ -140,11 +141,19 @@ export function createRecorder(
     },
 
     async stop(): Promise<Blob> {
-      await encoder.flush();
+      let flushError: unknown;
+      try {
+        await encoder.flush();
+      } catch (e) {
+        flushError = e;
+      } finally {
+        encoder.close();
+      }
       muxer.finalize();
       const buf = muxer.target.buffer;
       scaleCanvas = null;
       scaleCtx = null;
+      if (flushError) throw flushError;
       return new Blob([buf], { type: "video/mp4" });
     },
   };

--- a/src/tools/gradients/index.tsx
+++ b/src/tools/gradients/index.tsx
@@ -143,19 +143,22 @@ export default function Gradients() {
 
   async function toggleRecording() {
     if (isRecording) {
-      // Stop recording
       const recorder = recorderRef.current
       if (recorder) {
-        const blob = await recorder.stop()
-        recorderRef.current = null
-        setIsRecording(false)
-
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = generateFilename('gradient', 'mp4')
-        a.click()
-        URL.revokeObjectURL(url)
+        try {
+          const blob = await recorder.stop()
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = generateFilename('gradient', 'mp4')
+          a.click()
+          URL.revokeObjectURL(url)
+        } catch (e) {
+          console.error("Recording stop error:", e)
+        } finally {
+          recorderRef.current = null
+          setIsRecording(false)
+        }
       }
     } else {
       // Start recording — cap at 1080p for encoding performance

--- a/src/tools/lines/index.tsx
+++ b/src/tools/lines/index.tsx
@@ -218,15 +218,20 @@ export default function Lines() {
     if (isRecording) {
       const recorder = recorderRef.current
       if (recorder) {
-        const blob = await recorder.stop()
-        recorderRef.current = null
-        setIsRecording(false)
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = generateFilename('lines', 'mp4')
-        a.click()
-        URL.revokeObjectURL(url)
+        try {
+          const blob = await recorder.stop()
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = generateFilename('lines', 'mp4')
+          a.click()
+          URL.revokeObjectURL(url)
+        } catch (e) {
+          console.error("Recording stop error:", e)
+        } finally {
+          recorderRef.current = null
+          setIsRecording(false)
+        }
       }
     } else {
       const canvas = containerRef.current?.querySelector('canvas')

--- a/src/tools/marble/index.tsx
+++ b/src/tools/marble/index.tsx
@@ -84,15 +84,20 @@ export default function Marble() {
     if (isRecording) {
       const recorder = recorderRef.current
       if (recorder) {
-        const blob = await recorder.stop()
-        recorderRef.current = null
-        setIsRecording(false)
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement("a")
-        a.href = url
-        a.download = generateFilename("marble", "mp4")
-        a.click()
-        URL.revokeObjectURL(url)
+        try {
+          const blob = await recorder.stop()
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement("a")
+          a.href = url
+          a.download = generateFilename("marble", "mp4")
+          a.click()
+          URL.revokeObjectURL(url)
+        } catch (e) {
+          console.error("Recording stop error:", e)
+        } finally {
+          recorderRef.current = null
+          setIsRecording(false)
+        }
       }
     } else {
       const [sourceW, sourceH] = resolveCanvasSize(settings.canvasPreset, settings.customWidth, settings.customHeight)


### PR DESCRIPTION
## Summary
- Safari strictly follows the W3C spec and requires explicit `duration` on `VideoFrame` — without it, `EncodedVideoChunk.duration` is `null`, which mp4-muxer rejects with "addVideoChunkRaw's fourth argument (duration) must be a non-negative real number"
- Adds `duration: Math.round(1_000_000 / fps)` to the `VideoFrame` constructor in `createRecorder`
- Makes `stop()` properly close the encoder and re-throw flush errors so callers can handle failures
- Wraps the stop-recording path in all 3 tools (gradients, marble, lines) with try/catch/finally so the button always resets, even on encoder errors

## Test plan
- [ ] Record MP4 in Safari on the Gradients tool — verify it starts, stops, and downloads
- [ ] Record MP4 in Chrome — verify no regression
- [ ] Verify stop button resets to "Record MP4" after stopping in both browsers
- [ ] Test recording in Marble and Lines tools as well